### PR TITLE
SAFE-1205: Create parent product from base slug and build matrix product hierarchy

### DIFF
--- a/config/docs.json
+++ b/config/docs.json
@@ -6045,7 +6045,7 @@
           "payload": {
             "doc": {
               "modifiedDateRange": {
-                "startDateGMT": "2010-03-08T00:28:44.183Z",
+                "startDateGMT": "2010-03-06T00:28:44.183Z",
                 "endDateGMT": "2019-03-08T00:28:44.183Z"
               }
             }

--- a/config/docs.json
+++ b/config/docs.json
@@ -5816,6 +5816,366 @@
                   }
                 }
               }
+            },
+            {
+              "baseUri": "https://productlibrarydemo.iqmetrix.net",
+              "uri": "/v1/products/M5970",
+              "method": "GET",
+              "replyHeaders": {},
+              "statusCode": 200,
+              "responsePayload": {
+                "Id": "M9411",
+                "Name": "iPhone 7 Adidas Dual Layer Hard Cover Case",
+                "MasterProductId": 9411,
+                "VariationId": null,
+                "Owner": null,
+                "CanonicalClassification": {
+                  "TreeId": 1,
+                  "Id": 40,
+                  "Name": "Cases",
+                  "ParentCategories": [
+                    {
+                      "Id": 12,
+                      "Name": "Accessories"
+                    },
+                    {
+                      "Id": 37,
+                      "Name": "Cases & Protection"
+                    }
+                  ]
+                },
+                "ShortDescription": "This impact-resistant Adidas Originals Dual Layer Hard Cover Case.",
+                "LongDescription": "<p>Safeguard your iPhone 7 in style. This Dual Layered Hard Case (Taupe) features the Adidas logo on a bold canvas.</p>\n<p>Designed to give you easy access to every button and port, this protective iPhone 7 case has a hard, impact-resistant TPU shell to keep you covered. Impact-resistant TPU helps protect your iPhone against drops while the raised edge helps keep your screen scratch free.</p>",
+                "Manufacturer": {
+                  "Id": 99773,
+                  "Name": "adidas"
+                },
+                "MSRP": null,
+                "ReleaseDate": "2017-04-18T00:00:00Z",
+                "VariationInfo": [
+                  {
+                    "VariationId": 1,
+                    "Slug": "M9411-V1",
+                    "Fields": []
+                  },
+                  {
+                    "VariationId": 2,
+                    "Slug": "M9411-V2",
+                    "Fields": []
+                  },
+                  {
+                    "VariationId": 3,
+                    "Slug": "M9411-V3",
+                    "Fields": []
+                  },
+                  {
+                    "VariationId": 4,
+                    "Slug": "M9411-V4",
+                    "Fields": []
+                  }
+                ],
+                "Specifications": [
+                  {
+                    "Id": "6e70f04e-d8f0-4c2c-bf09-a0367bc76412",
+                    "Name": "Dimensions",
+                    "Fields": [
+                      {
+                        "Id": 40,
+                        "StringId": "Height",
+                        "DisplayName": "Height",
+                        "Name": "Height",
+                        "Value": "5.44",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      },
+                      {
+                        "Id": 41,
+                        "StringId": "Width",
+                        "DisplayName": "Width",
+                        "Name": "Width",
+                        "Value": "2.64",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      },
+                      {
+                        "Id": 42,
+                        "StringId": "Depth",
+                        "DisplayName": "Depth",
+                        "Name": "Depth",
+                        "Value": "0.28",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      }
+                    ]
+                  },
+                  {
+                    "Id": "144f294c-af12-46c4-912a-a0c796d22abc",
+                    "Name": "Features",
+                    "Fields": [
+                      {
+                        "Id": 10,
+                        "StringId": "Material",
+                        "DisplayName": "Material",
+                        "Name": "Material",
+                        "Value": "Polycarbonate / Polyurethane",
+                        "Type": "TextSingleLine",
+                        "Unit": ""
+                      },
+                      {
+                        "Id": 89,
+                        "StringId": "Screen Protector Included",
+                        "DisplayName": "Screen Protector Included",
+                        "Name": "Screen Protector Included",
+                        "Value": "No",
+                        "Type": "YesNo",
+                        "Unit": ""
+                      }
+                    ]
+                  },
+                  {
+                    "Id": "6ae2ca33-ea03-4c23-ab23-fe245c3635d8",
+                    "Name": "Packaging Dimensions",
+                    "Fields": [
+                      {
+                        "Id": 150,
+                        "StringId": "Packaging Width",
+                        "DisplayName": "Packaging Width",
+                        "Name": "Packaging Width",
+                        "Value": "4.13",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      }
+                    ]
+                  }
+                ],
+                "Assets": [
+                  {
+                    "Id": "8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                    "Name": "tmp3E4D.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  },
+                  {
+                    "Id": "f101dbf8-6bc5-4d1b-a430-a80a57b74210",
+                    "Name": "tmp208E.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/f101dbf8-6bc5-4d1b-a430-a80a57b74210",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  },
+                  {
+                    "Id": "0cb5f9f7-2dea-4c34-9f62-1a0e3511b196",
+                    "Name": "tmp2C67.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/0cb5f9f7-2dea-4c34-9f62-1a0e3511b196",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  },
+                  {
+                    "Id": "8e482267-f30c-47ec-b9e4-a4ecdc60c5d0",
+                    "Name": "tmp3552.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/8e482267-f30c-47ec-b9e4-a4ecdc60c5d0",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  }
+                ],
+                "ColorDefinition": null,
+                "HeroShotUri": "https://amsrc.iqmetrix.net/images/8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                "HeroShotId": "8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                "ManufacturerSkus": [],
+                "VendorSkus": [],
+                "UpcCodes": [],
+                "Region": null,
+                "Entity": null,
+                "HasColor": true,
+                "IsLinkedToCuratedProduct": true,
+                "IsSaleable": false,
+                "IsArchived": false,
+                "Version": 14
+              }
+            },
+            {
+              "baseUri": "https://productlibrarydemo.iqmetrix.net",
+              "uri": "/v1/products/M6855",
+              "method": "GET",
+              "replyHeaders": {},
+              "statusCode": 200,
+              "responsePayload": {
+                "Id": "M9411",
+                "Name": "iPhone 7 Adidas Dual Layer Hard Cover Case",
+                "MasterProductId": 9411,
+                "VariationId": null,
+                "Owner": null,
+                "CanonicalClassification": {
+                  "TreeId": 1,
+                  "Id": 40,
+                  "Name": "Cases",
+                  "ParentCategories": [
+                    {
+                      "Id": 12,
+                      "Name": "Accessories"
+                    },
+                    {
+                      "Id": 37,
+                      "Name": "Cases & Protection"
+                    }
+                  ]
+                },
+                "ShortDescription": "This impact-resistant Adidas Originals Dual Layer Hard Cover Case.",
+                "LongDescription": "<p>Safeguard your iPhone 7 in style. This Dual Layered Hard Case (Taupe) features the Adidas logo on a bold canvas.</p>\n<p>Designed to give you easy access to every button and port, this protective iPhone 7 case has a hard, impact-resistant TPU shell to keep you covered. Impact-resistant TPU helps protect your iPhone against drops while the raised edge helps keep your screen scratch free.</p>",
+                "Manufacturer": {
+                  "Id": 99773,
+                  "Name": "adidas"
+                },
+                "MSRP": null,
+                "ReleaseDate": "2017-04-18T00:00:00Z",
+                "VariationInfo": [
+                  {
+                    "VariationId": 1,
+                    "Slug": "M9411-V1",
+                    "Fields": []
+                  },
+                  {
+                    "VariationId": 2,
+                    "Slug": "M9411-V2",
+                    "Fields": []
+                  },
+                  {
+                    "VariationId": 3,
+                    "Slug": "M9411-V3",
+                    "Fields": []
+                  },
+                  {
+                    "VariationId": 4,
+                    "Slug": "M9411-V4",
+                    "Fields": []
+                  }
+                ],
+                "Specifications": [
+                  {
+                    "Id": "6e70f04e-d8f0-4c2c-bf09-a0367bc76412",
+                    "Name": "Dimensions",
+                    "Fields": [
+                      {
+                        "Id": 40,
+                        "StringId": "Height",
+                        "DisplayName": "Height",
+                        "Name": "Height",
+                        "Value": "5.44",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      },
+                      {
+                        "Id": 41,
+                        "StringId": "Width",
+                        "DisplayName": "Width",
+                        "Name": "Width",
+                        "Value": "2.64",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      },
+                      {
+                        "Id": 42,
+                        "StringId": "Depth",
+                        "DisplayName": "Depth",
+                        "Name": "Depth",
+                        "Value": "0.28",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      }
+                    ]
+                  },
+                  {
+                    "Id": "144f294c-af12-46c4-912a-a0c796d22abc",
+                    "Name": "Features",
+                    "Fields": [
+                      {
+                        "Id": 10,
+                        "StringId": "Material",
+                        "DisplayName": "Material",
+                        "Name": "Material",
+                        "Value": "Polycarbonate / Polyurethane",
+                        "Type": "TextSingleLine",
+                        "Unit": ""
+                      },
+                      {
+                        "Id": 89,
+                        "StringId": "Screen Protector Included",
+                        "DisplayName": "Screen Protector Included",
+                        "Name": "Screen Protector Included",
+                        "Value": "No",
+                        "Type": "YesNo",
+                        "Unit": ""
+                      }
+                    ]
+                  },
+                  {
+                    "Id": "6ae2ca33-ea03-4c23-ab23-fe245c3635d8",
+                    "Name": "Packaging Dimensions",
+                    "Fields": [
+                      {
+                        "Id": 150,
+                        "StringId": "Packaging Width",
+                        "DisplayName": "Packaging Width",
+                        "Name": "Packaging Width",
+                        "Value": "4.13",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      }
+                    ]
+                  }
+                ],
+                "Assets": [
+                  {
+                    "Id": "8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                    "Name": "tmp3E4D.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  },
+                  {
+                    "Id": "f101dbf8-6bc5-4d1b-a430-a80a57b74210",
+                    "Name": "tmp208E.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/f101dbf8-6bc5-4d1b-a430-a80a57b74210",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  },
+                  {
+                    "Id": "0cb5f9f7-2dea-4c34-9f62-1a0e3511b196",
+                    "Name": "tmp2C67.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/0cb5f9f7-2dea-4c34-9f62-1a0e3511b196",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  },
+                  {
+                    "Id": "8e482267-f30c-47ec-b9e4-a4ecdc60c5d0",
+                    "Name": "tmp3552.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/8e482267-f30c-47ec-b9e4-a4ecdc60c5d0",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  }
+                ],
+                "ColorDefinition": null,
+                "HeroShotUri": "https://amsrc.iqmetrix.net/images/8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                "HeroShotId": "8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                "ManufacturerSkus": [],
+                "VendorSkus": [],
+                "UpcCodes": [],
+                "Region": null,
+                "Entity": null,
+                "HasColor": true,
+                "IsLinkedToCuratedProduct": true,
+                "IsSaleable": false,
+                "IsArchived": false,
+                "Version": 14
+              }
             }
           ],
           "channelProfile": {
@@ -5937,6 +6297,366 @@
                     ]
                   }
                 }
+              }
+            },
+            {
+              "baseUri": "https://productlibrarydemo.iqmetrix.net",
+              "uri": "/v1/products/M5970",
+              "method": "GET",
+              "replyHeaders": {},
+              "statusCode": 200,
+              "responsePayload": {
+                "Id": "M9411",
+                "Name": "iPhone 7 Adidas Dual Layer Hard Cover Case",
+                "MasterProductId": 9411,
+                "VariationId": null,
+                "Owner": null,
+                "CanonicalClassification": {
+                  "TreeId": 1,
+                  "Id": 40,
+                  "Name": "Cases",
+                  "ParentCategories": [
+                    {
+                      "Id": 12,
+                      "Name": "Accessories"
+                    },
+                    {
+                      "Id": 37,
+                      "Name": "Cases & Protection"
+                    }
+                  ]
+                },
+                "ShortDescription": "This impact-resistant Adidas Originals Dual Layer Hard Cover Case.",
+                "LongDescription": "<p>Safeguard your iPhone 7 in style. This Dual Layered Hard Case (Taupe) features the Adidas logo on a bold canvas.</p>\n<p>Designed to give you easy access to every button and port, this protective iPhone 7 case has a hard, impact-resistant TPU shell to keep you covered. Impact-resistant TPU helps protect your iPhone against drops while the raised edge helps keep your screen scratch free.</p>",
+                "Manufacturer": {
+                  "Id": 99773,
+                  "Name": "adidas"
+                },
+                "MSRP": null,
+                "ReleaseDate": "2017-04-18T00:00:00Z",
+                "VariationInfo": [
+                  {
+                    "VariationId": 1,
+                    "Slug": "M9411-V1",
+                    "Fields": []
+                  },
+                  {
+                    "VariationId": 2,
+                    "Slug": "M9411-V2",
+                    "Fields": []
+                  },
+                  {
+                    "VariationId": 3,
+                    "Slug": "M9411-V3",
+                    "Fields": []
+                  },
+                  {
+                    "VariationId": 4,
+                    "Slug": "M9411-V4",
+                    "Fields": []
+                  }
+                ],
+                "Specifications": [
+                  {
+                    "Id": "6e70f04e-d8f0-4c2c-bf09-a0367bc76412",
+                    "Name": "Dimensions",
+                    "Fields": [
+                      {
+                        "Id": 40,
+                        "StringId": "Height",
+                        "DisplayName": "Height",
+                        "Name": "Height",
+                        "Value": "5.44",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      },
+                      {
+                        "Id": 41,
+                        "StringId": "Width",
+                        "DisplayName": "Width",
+                        "Name": "Width",
+                        "Value": "2.64",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      },
+                      {
+                        "Id": 42,
+                        "StringId": "Depth",
+                        "DisplayName": "Depth",
+                        "Name": "Depth",
+                        "Value": "0.28",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      }
+                    ]
+                  },
+                  {
+                    "Id": "144f294c-af12-46c4-912a-a0c796d22abc",
+                    "Name": "Features",
+                    "Fields": [
+                      {
+                        "Id": 10,
+                        "StringId": "Material",
+                        "DisplayName": "Material",
+                        "Name": "Material",
+                        "Value": "Polycarbonate / Polyurethane",
+                        "Type": "TextSingleLine",
+                        "Unit": ""
+                      },
+                      {
+                        "Id": 89,
+                        "StringId": "Screen Protector Included",
+                        "DisplayName": "Screen Protector Included",
+                        "Name": "Screen Protector Included",
+                        "Value": "No",
+                        "Type": "YesNo",
+                        "Unit": ""
+                      }
+                    ]
+                  },
+                  {
+                    "Id": "6ae2ca33-ea03-4c23-ab23-fe245c3635d8",
+                    "Name": "Packaging Dimensions",
+                    "Fields": [
+                      {
+                        "Id": 150,
+                        "StringId": "Packaging Width",
+                        "DisplayName": "Packaging Width",
+                        "Name": "Packaging Width",
+                        "Value": "4.13",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      }
+                    ]
+                  }
+                ],
+                "Assets": [
+                  {
+                    "Id": "8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                    "Name": "tmp3E4D.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  },
+                  {
+                    "Id": "f101dbf8-6bc5-4d1b-a430-a80a57b74210",
+                    "Name": "tmp208E.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/f101dbf8-6bc5-4d1b-a430-a80a57b74210",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  },
+                  {
+                    "Id": "0cb5f9f7-2dea-4c34-9f62-1a0e3511b196",
+                    "Name": "tmp2C67.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/0cb5f9f7-2dea-4c34-9f62-1a0e3511b196",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  },
+                  {
+                    "Id": "8e482267-f30c-47ec-b9e4-a4ecdc60c5d0",
+                    "Name": "tmp3552.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/8e482267-f30c-47ec-b9e4-a4ecdc60c5d0",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  }
+                ],
+                "ColorDefinition": null,
+                "HeroShotUri": "https://amsrc.iqmetrix.net/images/8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                "HeroShotId": "8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                "ManufacturerSkus": [],
+                "VendorSkus": [],
+                "UpcCodes": [],
+                "Region": null,
+                "Entity": null,
+                "HasColor": true,
+                "IsLinkedToCuratedProduct": true,
+                "IsSaleable": false,
+                "IsArchived": false,
+                "Version": 14
+              }
+            },
+            {
+              "baseUri": "https://productlibrarydemo.iqmetrix.net",
+              "uri": "/v1/products/M6855",
+              "method": "GET",
+              "replyHeaders": {},
+              "statusCode": 200,
+              "responsePayload": {
+                "Id": "M9411",
+                "Name": "iPhone 7 Adidas Dual Layer Hard Cover Case",
+                "MasterProductId": 9411,
+                "VariationId": null,
+                "Owner": null,
+                "CanonicalClassification": {
+                  "TreeId": 1,
+                  "Id": 40,
+                  "Name": "Cases",
+                  "ParentCategories": [
+                    {
+                      "Id": 12,
+                      "Name": "Accessories"
+                    },
+                    {
+                      "Id": 37,
+                      "Name": "Cases & Protection"
+                    }
+                  ]
+                },
+                "ShortDescription": "This impact-resistant Adidas Originals Dual Layer Hard Cover Case.",
+                "LongDescription": "<p>Safeguard your iPhone 7 in style. This Dual Layered Hard Case (Taupe) features the Adidas logo on a bold canvas.</p>\n<p>Designed to give you easy access to every button and port, this protective iPhone 7 case has a hard, impact-resistant TPU shell to keep you covered. Impact-resistant TPU helps protect your iPhone against drops while the raised edge helps keep your screen scratch free.</p>",
+                "Manufacturer": {
+                  "Id": 99773,
+                  "Name": "adidas"
+                },
+                "MSRP": null,
+                "ReleaseDate": "2017-04-18T00:00:00Z",
+                "VariationInfo": [
+                  {
+                    "VariationId": 1,
+                    "Slug": "M9411-V1",
+                    "Fields": []
+                  },
+                  {
+                    "VariationId": 2,
+                    "Slug": "M9411-V2",
+                    "Fields": []
+                  },
+                  {
+                    "VariationId": 3,
+                    "Slug": "M9411-V3",
+                    "Fields": []
+                  },
+                  {
+                    "VariationId": 4,
+                    "Slug": "M9411-V4",
+                    "Fields": []
+                  }
+                ],
+                "Specifications": [
+                  {
+                    "Id": "6e70f04e-d8f0-4c2c-bf09-a0367bc76412",
+                    "Name": "Dimensions",
+                    "Fields": [
+                      {
+                        "Id": 40,
+                        "StringId": "Height",
+                        "DisplayName": "Height",
+                        "Name": "Height",
+                        "Value": "5.44",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      },
+                      {
+                        "Id": 41,
+                        "StringId": "Width",
+                        "DisplayName": "Width",
+                        "Name": "Width",
+                        "Value": "2.64",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      },
+                      {
+                        "Id": 42,
+                        "StringId": "Depth",
+                        "DisplayName": "Depth",
+                        "Name": "Depth",
+                        "Value": "0.28",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      }
+                    ]
+                  },
+                  {
+                    "Id": "144f294c-af12-46c4-912a-a0c796d22abc",
+                    "Name": "Features",
+                    "Fields": [
+                      {
+                        "Id": 10,
+                        "StringId": "Material",
+                        "DisplayName": "Material",
+                        "Name": "Material",
+                        "Value": "Polycarbonate / Polyurethane",
+                        "Type": "TextSingleLine",
+                        "Unit": ""
+                      },
+                      {
+                        "Id": 89,
+                        "StringId": "Screen Protector Included",
+                        "DisplayName": "Screen Protector Included",
+                        "Name": "Screen Protector Included",
+                        "Value": "No",
+                        "Type": "YesNo",
+                        "Unit": ""
+                      }
+                    ]
+                  },
+                  {
+                    "Id": "6ae2ca33-ea03-4c23-ab23-fe245c3635d8",
+                    "Name": "Packaging Dimensions",
+                    "Fields": [
+                      {
+                        "Id": 150,
+                        "StringId": "Packaging Width",
+                        "DisplayName": "Packaging Width",
+                        "Name": "Packaging Width",
+                        "Value": "4.13",
+                        "Type": "Float",
+                        "Unit": "inches"
+                      }
+                    ]
+                  }
+                ],
+                "Assets": [
+                  {
+                    "Id": "8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                    "Name": "tmp3E4D.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  },
+                  {
+                    "Id": "f101dbf8-6bc5-4d1b-a430-a80a57b74210",
+                    "Name": "tmp208E.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/f101dbf8-6bc5-4d1b-a430-a80a57b74210",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  },
+                  {
+                    "Id": "0cb5f9f7-2dea-4c34-9f62-1a0e3511b196",
+                    "Name": "tmp2C67.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/0cb5f9f7-2dea-4c34-9f62-1a0e3511b196",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  },
+                  {
+                    "Id": "8e482267-f30c-47ec-b9e4-a4ecdc60c5d0",
+                    "Name": "tmp3552.png",
+                    "Uri": "https://amsrc.iqmetrix.net/images/8e482267-f30c-47ec-b9e4-a4ecdc60c5d0",
+                    "Type": "Image",
+                    "IsHidden": false,
+                    "IsRolledUp": true
+                  }
+                ],
+                "ColorDefinition": null,
+                "HeroShotUri": "https://amsrc.iqmetrix.net/images/8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                "HeroShotId": "8d9e3ea1-f562-4d92-b74e-2d877ea1378e",
+                "ManufacturerSkus": [],
+                "VendorSkus": [],
+                "UpcCodes": [],
+                "Region": null,
+                "Entity": null,
+                "HasColor": true,
+                "IsLinkedToCuratedProduct": true,
+                "IsSaleable": false,
+                "IsArchived": false,
+                "Version": 14
               }
             }
           ],

--- a/functions/GetProductMatrixFromQuery.js
+++ b/functions/GetProductMatrixFromQuery.js
@@ -1,223 +1,276 @@
 function GetProductMatrixFromQuery(ncUtil, channelProfile, flowContext, payload, callback) {
-    const nc = require("./util/ncUtils");
-    const referenceLocations = ["productBusinessReferences"];
-    const stub = new nc.Stub("GetProductMatrixFromQuery", referenceLocations, ...arguments);
+  const nc = require("./util/ncUtils");
+  const referenceLocations = ["productBusinessReferences"];
+  const stub = new nc.Stub("GetProductMatrixFromQuery", referenceLocations, ...arguments);
 
-    validateFunction()
-        .then(getProductLists)
-        .then(keepMatrixItems)
-        .then(flattenProductLists)
-        .then(getProductDetails)
-        .then(keepModifiedItems)
-        .then(filterVendors)
-        .then(buildResponseObject)
-        .catch(handleError)
-        .then(() => callback(stub.out))
-        .catch(error => {
-            logError(`The callback function threw an exception: ${error}`);
-            setTimeout(() => {
-                throw error;
-            });
-        });
+  validateFunction()
+    .then(getProductLists)
+    .then(keepMatrixItems)
+    .then(flattenProductLists)
+    .then(addParents)
+    .then(getProductDetails)
+    .then(keepModifiedItems)
+    .then(filterVendors)
+    .then(buildResponseObject)
+    .catch(handleError)
+    .then(() => callback(stub.out))
+    .catch(error => {
+      logError(`The callback function threw an exception: ${error}`);
+      setTimeout(() => {
+        throw error;
+      });
+    });
 
-    function logInfo(msg) {
-        stub.log(msg, "info");
-    }
+  function logInfo(msg) {
+    stub.log(msg, "info");
+  }
 
-    function logWarn(msg) {
-        stub.log(msg, "warn");
-    }
+  function logWarn(msg) {
+    stub.log(msg, "warn");
+  }
 
-    function logError(msg) {
-        stub.log(msg, "error");
-    }
+  function logError(msg) {
+    stub.log(msg, "error");
+  }
 
-    async function validateFunction() {
-        if (stub.messages.length === 0) {
-            if (!nc.isNonEmptyArray(stub.channelProfile.channelSettingsValues.subscriptionLists)) {
-                stub.messages.push(
-                    `The channelProfile.channelSettingsValues.subscriptionLists array is ${
-                        stub.channelProfile.channelSettingsValues.subscriptionLists == null ? "missing" : "invalid"
-                    }.`
-                );
-            }
-
-            if (!nc.isObject(stub.payload.doc.modifiedDateRange)) {
-                stub.messages.push(
-                    `The payload.doc.modifiedDateRange object is ${
-                        stub.payload.doc.modifiedDateRange == null ? "missing" : "invalid"
-                    }.`
-                );
-            } else {
-                if (!nc.isNonEmptyString(stub.payload.doc.modifiedDateRange.startDateGMT)) {
-                    stub.messages.push(
-                        `The payload.doc.modifiedDateRange.startDateGMT string is ${
-                            stub.payload.doc.modifiedDateRange.startDateGMT == null ? "missing" : "invalid"
-                        }.`
-                    );
-                }
-                if (!nc.isNonEmptyString(stub.payload.doc.modifiedDateRange.endDateGMT)) {
-                    stub.messages.push(
-                        `The payload.doc.modifiedDateRange.endDateGMT string is ${
-                            stub.payload.doc.modifiedDateRange.endDateGMT == null ? "missing" : "invalid"
-                        }.`
-                    );
-                }
-            }
-        }
-
-        if (stub.messages.length > 0) {
-            stub.messages.forEach(msg => logError(msg));
-            stub.out.ncStatusCode = 400;
-            throw new Error(`Invalid request [${stub.messages.join(" ")}]`);
-        }
-        logInfo("Function is valid.");
-    }
-
-    async function getProductLists() {
-        logInfo("Get product lists...");
-        return await Promise.all(stub.channelProfile.channelSettingsValues.subscriptionLists.map(getProductList));
-    }
-
-    async function getProductList(subscriptionList) {
-        logInfo(`Get product list [${subscriptionList.listId}]...`);
-        const response = await stub.request.get({
-            url: `${stub.channelProfile.channelSettingsValues.protocol}://catalogs${
-                stub.channelProfile.channelSettingsValues.environment
-            }.iqmetrix.net/v1/Companies(${stub.channelProfile.channelAuthValues.company_id})/Catalog/Items(SourceId=${
-                subscriptionList.listId
-            })`
-        });
-        response.body.Items.forEach(item => {
-            item.subscriptionList = subscriptionList;
-        });
-        return response.body.Items;
-    }
-
-    async function keepMatrixItems(productLists) {
-        logInfo("Keep matrix items...");
-        let totalCount = 0;
-        let matrixCount = 0;
-        const filteredProductLists = productLists.map(productList => {
-            totalCount = totalCount + productList.length;
-            const filtered = [];
-            for (let i = 0; i < productList.length; i++) {
-                const product = productList[i];
-                if (productList.filter(p => p.Slug.split("-")[0] === product.Slug.split("-")[0]).length > 1) {
-                    filtered.push(product);
-                }
-            }
-            matrixCount = matrixCount + filtered.length;
-            return filtered;
-        });
-        logInfo(`${matrixCount} of ${totalCount} products are matrix variants.`);
-        return filteredProductLists;
-    }
-
-    async function flattenProductLists(productLists) {
-        logInfo("Flatten product lists...");
-        return [].concat(...productLists);
-    }
-
-    async function getProductDetails(productList) {
-        logInfo("Get product details...");
-        const allIds = productList.map(p => p.CatalogItemId);
-        const batchedIds = [];
-        const max = 500;
-        let current = 0;
-        do {
-            const batchIds = allIds.slice(current, current + max);
-            batchedIds.push(batchIds);
-            current = current + max;
-        } while (current < allIds.length);
-        const batchedDetails = await Promise.all(batchedIds.map(getProductDetailsBulk));
-        const CatalogItems = Object.assign({}, ...batchedDetails);
-        productList.forEach(product => {
-            product.ProductDetails = CatalogItems[product.CatalogItemId];
-        });
-        return productList;
-    }
-
-    async function getProductDetailsBulk(catalogIds) {
-        logInfo(`Get ${catalogIds.length} product details...`);
-        const response = await stub.request.post({
-            url: `${stub.channelProfile.channelSettingsValues.protocol}://catalogs${
-                stub.channelProfile.channelSettingsValues.environment
-            }.iqmetrix.net/v1/Companies(${
-                stub.channelProfile.channelAuthValues.company_id
-            })/Catalog/Items/ProductDetails/Bulk`,
-            body: {
-                CatalogItemIds: catalogIds
-            }
-        });
-        return response.body.CatalogItems;
-    }
-
-    async function keepModifiedItems(productList) {
-        logInfo("Keep modified items...");
-        const start = Date.parse(stub.payload.doc.modifiedDateRange.startDateGMT);
-        const end = Date.parse(stub.payload.doc.modifiedDateRange.endDateGMT);
-        const products = productList.filter(product => {
-            const headerMod = Date.parse(product.DateUpdatedUtc);
-            const detailMod = Date.parse(product.ProductDetails.DateUpdatedUtc);
-            return (headerMod >= start && headerMod <= end) || (detailMod >= start && detailMod <= end);
-        });
-        logInfo(
-            `${products.length} of ${productList.length} products have been modified withing the given date range.`
+  async function validateFunction() {
+    if (stub.messages.length === 0) {
+      if (!nc.isNonEmptyArray(stub.channelProfile.channelSettingsValues.subscriptionLists)) {
+        stub.messages.push(
+          `The channelProfile.channelSettingsValues.subscriptionLists array is ${
+            stub.channelProfile.channelSettingsValues.subscriptionLists == null ? "missing" : "invalid"
+          }.`
         );
-        return products;
+      }
+
+      if (!nc.isObject(stub.payload.doc.modifiedDateRange)) {
+        stub.messages.push(
+          `The payload.doc.modifiedDateRange object is ${
+            stub.payload.doc.modifiedDateRange == null ? "missing" : "invalid"
+          }.`
+        );
+      } else {
+        if (!nc.isNonEmptyString(stub.payload.doc.modifiedDateRange.startDateGMT)) {
+          stub.messages.push(
+            `The payload.doc.modifiedDateRange.startDateGMT string is ${
+              stub.payload.doc.modifiedDateRange.startDateGMT == null ? "missing" : "invalid"
+            }.`
+          );
+        }
+        if (!nc.isNonEmptyString(stub.payload.doc.modifiedDateRange.endDateGMT)) {
+          stub.messages.push(
+            `The payload.doc.modifiedDateRange.endDateGMT string is ${
+              stub.payload.doc.modifiedDateRange.endDateGMT == null ? "missing" : "invalid"
+            }.`
+          );
+        }
+      }
     }
 
-    async function filterVendors(productList) {
-        logInfo("Filter vendors...");
-        productList.forEach(product => {
-            const supplierId = product.subscriptionList.supplierId;
-            const VendorSkus = product.ProductDetails.VendorSkus.filter(vendor => {
-                return vendor.Entity && vendor.Entity.Id === supplierId;
-            });
-            product.VendorSku = VendorSkus[0];
+    if (stub.messages.length > 0) {
+      stub.messages.forEach(msg => logError(msg));
+      stub.out.ncStatusCode = 400;
+      throw new Error(`Invalid request [${stub.messages.join(" ")}]`);
+    }
+    logInfo("Function is valid.");
+  }
+
+  async function getProductLists() {
+    logInfo("Get product lists...");
+    return await Promise.all(stub.channelProfile.channelSettingsValues.subscriptionLists.map(getProductList));
+  }
+
+  async function getProductList(subscriptionList) {
+    logInfo(`Get product list [${subscriptionList.listId}]...`);
+    const response = await stub.request.get({
+      url: `${stub.channelProfile.channelSettingsValues.protocol}://catalogs${
+        stub.channelProfile.channelSettingsValues.environment
+      }.iqmetrix.net/v1/Companies(${stub.channelProfile.channelAuthValues.company_id})/Catalog/Items(SourceId=${
+        subscriptionList.listId
+      })`
+    });
+    response.body.Items.forEach(item => {
+      item.subscriptionList = subscriptionList;
+    });
+    return response.body.Items;
+  }
+
+  async function keepMatrixItems(productLists) {
+    logInfo("Keep matrix items...");
+    let totalCount = 0;
+    let matrixCount = 0;
+    const filteredProductLists = productLists.map(productList => {
+      totalCount = totalCount + productList.length;
+      const filtered = [];
+      for (let i = 0; i < productList.length; i++) {
+        const product = productList[i];
+        if (productList.filter(p => p.Slug.split("-")[0] === product.Slug.split("-")[0]).length > 1) {
+          filtered.push(product);
+        }
+      }
+      matrixCount = matrixCount + filtered.length;
+      return filtered;
+    });
+    logInfo(`${matrixCount} of ${totalCount} products are matrix variants.`);
+    return filteredProductLists;
+  }
+
+  async function flattenProductLists(productLists) {
+    logInfo("Flatten product lists...");
+    return [].concat(...productLists);
+  }
+
+  async function addParents(productList) {
+    let slugSet = new Set();
+    productList.forEach(product => {
+      slugSet.add(product.Slug.split("-")[0]);
+    });
+    slugSet.forEach(slug => {
+      if (!productList.find(p => p.Slug === slug)) {
+        productList.push({
+          Slug: slug,
+          subscriptionList: productList.find(p => p.Slug.split("-")[0] === slug).subscriptionList,
+          ProductDetails: {}
         });
-        return productList;
+      }
+    });
+
+    return productList;
+  }
+
+  async function getProductDetails(productList) {
+    logInfo("Get product details...");
+    const allIds = productList.map(p => p.CatalogItemId);
+    const batchedIds = [];
+    const max = 500;
+    let current = 0;
+    do {
+      const batchIds = allIds.slice(current, current + max);
+      batchedIds.push(batchIds);
+      current = current + max;
+    } while (current < allIds.length);
+    const batchedDetails = await Promise.all(batchedIds.map(getProductDetailsBulk));
+    const CatalogItems = Object.assign({}, ...batchedDetails);
+
+    for (let index = 0; index < productList.length; index++) {
+      const product = productList[index];
+      product.ProductDetails = CatalogItems[product.CatalogItemId];
+
+      if (!product.ProductDetails) {
+        const response = await stub.request.get({
+          url: `${stub.channelProfile.channelSettingsValues.protocol}://productlibrary${
+            stub.channelProfile.channelSettingsValues.environment
+          }.iqmetrix.net/v1/products/${product.Slug}`
+        });
+        product.ProductDetails = response.body;
+      }
     }
 
-    async function buildResponseObject(products) {
-        if (products.length > 0) {
-            logInfo(`Submitting ${products.length} modified products...`);
-            stub.out.ncStatusCode = 200;
-            stub.out.payload = [];
-            products.forEach(product => {
-                stub.out.payload.push({
-                    doc: product,
-                    productMatrixRemoteID: product.CatalogItemId,
-                    productMatrixBusinessReference: nc.extractBusinessReferences(
-                        stub.channelProfile.productMatrixBusinessReferences,
-                        product
-                    )
-                });
-            });
-        } else {
-            logInfo("No modified products found.");
-            stub.out.ncStatusCode = 204;
-        }
-    }
+    return productList;
+  }
 
-    async function handleError(error) {
-        logError(error);
-        if (error.name === "StatusCodeError") {
-            stub.out.response.endpointStatusCode = error.statusCode;
-            stub.out.response.endpointStatusMessage = error.message;
-            if (error.statusCode >= 500) {
-                stub.out.ncStatusCode = 500;
-            } else if (error.statusCode === 429) {
-                logWarn("Request was throttled.");
-                stub.out.ncStatusCode = 429;
-            } else {
-                stub.out.ncStatusCode = 400;
-            }
-        }
-        stub.out.payload.error = error;
-        stub.out.ncStatusCode = stub.out.ncStatusCode || 500;
+  async function getProductDetailsBulk(catalogIds) {
+    logInfo(`Get ${catalogIds.length} product details...`);
+    const response = await stub.request.post({
+      url: `${stub.channelProfile.channelSettingsValues.protocol}://catalogs${
+        stub.channelProfile.channelSettingsValues.environment
+      }.iqmetrix.net/v1/Companies(${
+        stub.channelProfile.channelAuthValues.company_id
+      })/Catalog/Items/ProductDetails/Bulk`,
+      body: {
+        CatalogItemIds: catalogIds
+      }
+    });
+    return response.body.CatalogItems;
+  }
+
+  async function keepModifiedItems(productList) {
+    logInfo("Keep modified items...");
+    const start = Date.parse(stub.payload.doc.modifiedDateRange.startDateGMT);
+    const end = Date.parse(stub.payload.doc.modifiedDateRange.endDateGMT);
+    const modifiedProducts = productList.filter(product => {
+      const headerMod = Date.parse(product.DateUpdatedUtc);
+      const detailMod = Date.parse(product.ProductDetails.DateUpdatedUtc);
+      return (headerMod >= start && headerMod <= end) || (detailMod >= start && detailMod <= end);
+    });
+    logInfo(
+      `${modifiedProducts.length} of ${productList.length} variants have been modified within the given date range.`
+    );
+
+    let parentSlugs = new Set();
+    modifiedProducts.forEach(p => {
+      parentSlugs.add(p.Slug.split("-")[0]);
+    });
+
+    const products = productList.filter(product => {
+      return parentSlugs.has(product.Slug.split("-")[0]);
+    });
+
+    return products;
+  }
+
+  async function filterVendors(productList) {
+    logInfo("Filter vendors...");
+    productList.forEach(product => {
+      const supplierId = product.subscriptionList.supplierId;
+      const VendorSkus = product.ProductDetails.VendorSkus.filter(vendor => {
+            return vendor.Entity && vendor.Entity.Id === supplierId;
+          });
+      product.VendorSku = VendorSkus[0];
+    });
+    return productList;
+  }
+
+  async function buildResponseObject(products) {
+    if (products.length > 0) {
+      const matrixProducts = [];
+      let parentSlugs = new Set();
+      products.forEach(p => {
+        parentSlugs.add(p.Slug.split("-")[0]);
+      });
+      parentSlugs.forEach(parentSlug => {
+        matrixProducts.push(products.find(p => p.Slug === parentSlug));
+      });
+
+      matrixProducts.forEach(matrixProduct => {
+        matrixProduct.MatrixChildren = products.filter(
+          p => p.Slug.split("-")[0] === matrixProduct.Slug && p.Slug.split("-")[1] != null
+        );
+      });
+
+      logInfo(`Submitting ${matrixProducts.length} modified matrix products...`);
+      stub.out.ncStatusCode = 200;
+      stub.out.payload = [];
+      matrixProducts.forEach(product => {
+        stub.out.payload.push({
+          doc: product,
+          productRemoteID: product.CatalogItemId,
+          productBusinessReference: nc.extractBusinessReferences(stub.channelProfile.productBusinessReferences, product)
+        });
+      });
+    } else {
+      logInfo("No modified products found.");
+      stub.out.ncStatusCode = 204;
     }
+  }
+
+  async function handleError(error) {
+    logError(error);
+    if (error.name === "StatusCodeError") {
+      stub.out.response.endpointStatusCode = error.statusCode;
+      stub.out.response.endpointStatusMessage = error.message;
+      if (error.statusCode >= 500) {
+        stub.out.ncStatusCode = 500;
+      } else if (error.statusCode === 429) {
+        logWarn("Request was throttled.");
+        stub.out.ncStatusCode = 429;
+      } else {
+        stub.out.ncStatusCode = 400;
+      }
+    }
+    stub.out.payload.error = error;
+    stub.out.ncStatusCode = stub.out.ncStatusCode || 500;
+  }
 }
 
 module.exports.GetProductMatrixFromQuery = GetProductMatrixFromQuery;

--- a/functions/GetProductMatrixFromQuery.js
+++ b/functions/GetProductMatrixFromQuery.js
@@ -233,7 +233,7 @@ function GetProductMatrixFromQuery(ncUtil, channelProfile, flowContext, payload,
       });
 
       matrixProducts.forEach(matrixProduct => {
-        matrixProduct.MatrixChildren = products.filter(
+        matrixProduct.matrixChildren = products.filter(
           p => p.Slug.split("-")[0] === matrixProduct.Slug && p.Slug.split("-")[1] != null
         );
       });

--- a/functions/GetProductPricingFromQuery.js
+++ b/functions/GetProductPricingFromQuery.js
@@ -222,7 +222,7 @@ function GetProductPricingFromQuery(ncUtil, channelProfile, flowContext, payload
                     doc: product,
                     productPricingRemoteID: product.CatalogItemId,
                     productPricingBusinessReference: nc.extractBusinessReferences(
-                        stub.channelProfileproductPricingBusinessReferences,
+                        stub.channelProfile.productPricingBusinessReferences,
                         product
                     )
                 });

--- a/functions/GetProductSimpleFromQuery.js
+++ b/functions/GetProductSimpleFromQuery.js
@@ -188,9 +188,9 @@ function GetProductSimpleFromQuery(ncUtil, channelProfile, flowContext, payload,
             products.forEach(product => {
                 stub.out.payload.push({
                     doc: product,
-                    productSimpleRemoteID: product.CatalogItemId,
-                    productSimpleBusinessReference: nc.extractBusinessReferences(
-                        stub.channelProfile.productSimpleBusinessReferences,
+                    productRemoteID: product.CatalogItemId,
+                    productBusinessReference: nc.extractBusinessReferences(
+                        stub.channelProfile.productBusinessReferences,
                         product
                     )
                 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nchannel/iqmetrix-dropship-channel",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
   "scripts": {
     "test": "mocha --timeout 10000 validation/*.spec.js"
   },
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/schema/GetProduct.json
+++ b/schema/GetProduct.json
@@ -94,11 +94,17 @@
           "ProductDetails": {
             "$ref": "#/definitions/ProductDetails"
           },
+          "VendorSku": {
+            "$ref": "#/definitions/VendorSku"
+          },
           "Pricing": {
             "$ref": "#/definitions/Pricing"
           },
           "SupplierSku": {
             "$ref": "#/definitions/SupplierSku"
+          },
+          "MatrixChildren": {
+            "$ref": "#/definitions/MatrixChildren"
           }
         }
       },
@@ -582,37 +588,7 @@
             "title": "VendorSkus (Array[Sku])",
             "description": "Vendor SKUs",
             "items": {
-              "type": "object",
-              "properties": {
-                "Value": {
-                  "type": "string",
-                  "title": "Value (String)",
-                  "description": "Value"
-                },
-                "Description": {
-                  "type": "string",
-                  "title": "Description (String)",
-                  "description": "Description"
-                },
-                "Entity": {
-                  "type": "object",
-                  "title": "Entity (object)",
-                  "description": "Identifier for an Entity this SKU is associated with",
-                  "properties": {
-                    "Id": {
-                      "type": "integer",
-                      "title": "Id (Integer)",
-                      "description":
-                        "Identifier of an Entity used for Entity Revisions. See Revisions for more information"
-                    },
-                    "Name": {
-                      "type": "string",
-                      "title": "Name (String)",
-                      "description": "Entity name"
-                    }
-                  }
-                }
-              }
+              "$ref": "#/definitions/VendorSku"
             }
           },
           "UpcCodes": {
@@ -710,6 +686,38 @@
             "type": "integer",
             "title": "Version (Integer)",
             "description": "Latest revision number"
+          }
+        }
+      },
+      "VendorSku": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string",
+            "title": "Value (String)",
+            "description": "Value"
+          },
+          "Description": {
+            "type": "string",
+            "title": "Description (String)",
+            "description": "Description"
+          },
+          "Entity": {
+            "type": "object",
+            "title": "Entity (object)",
+            "description": "Identifier for an Entity this SKU is associated with",
+            "properties": {
+              "Id": {
+                "type": "integer",
+                "title": "Id (Integer)",
+                "description": "Identifier of an Entity used for Entity Revisions. See Revisions for more information"
+              },
+              "Name": {
+                "type": "string",
+                "title": "Name (String)",
+                "description": "Entity name"
+              }
+            }
           }
         }
       },
@@ -835,6 +843,12 @@
             "type": "string",
             "title": "LastModifiedDateUtc (DateTime)"
           }
+        }
+      },
+      "MatrixChildren": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/CatalogItem"
         }
       }
     }

--- a/schema/GetProduct.json
+++ b/schema/GetProduct.json
@@ -103,8 +103,8 @@
           "SupplierSku": {
             "$ref": "#/definitions/SupplierSku"
           },
-          "MatrixChildren": {
-            "$ref": "#/definitions/MatrixChildren"
+          "matrixChildren": {
+            "$ref": "#/definitions/matrixChildren"
           }
         }
       },
@@ -845,7 +845,7 @@
           }
         }
       },
-      "MatrixChildren": {
+      "matrixChildren": {
         "type": "array",
         "items": {
           "$ref": "#/definitions/CatalogItem"


### PR DESCRIPTION
Modified Get Matrix Products to create a parent product based on the base slug value of the matrix variants.  Using this base slug, we make an additional call to a new endpoint to get product details.  Then adds all the variants as children of the new matrix product parent (in MatrixChildren array).


Notes from Jira ticket:

Current GET Product Matrix stub pulls in all related products by base slug number in the following format "12345-V1", "12345-V2", etc.

The stub should also make an additional call for product details on the base value ("12345") to provide data on parent product details.