### PR TITLE
Add additional API calls to GetFulfillment and GetPaymentCapture

### DIFF
--- a/config/docs.json
+++ b/config/docs.json
@@ -2019,7 +2019,8 @@
           "defaultHeaders": {},
           "links": [
             {
-              "uri": "/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09:59:59.999Z%20and%20updatedUtc%20lt%202017-05-12T12:00:00.001Z&page=1&pageSize=5",
+              "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net",
+              "uri": "/v1/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09%3A59%3A59.999Z%20and%20updatedUtc%20lt%202017-05-12T12%3A00%3A00.001Z&page=1&pageSize=5&sortBy=createdUtc&sortOrder=asc",
               "method": "GET",
               "replyHeaders": {},
               "statusCode": 200,
@@ -2127,6 +2128,69 @@
                 "createdUtc": "2017-03-16T18:06:16.7950000Z",
                 "updatedUtc": "2017-03-13T19:36:26.2620000Z"
               }
+            },
+            {
+              "baseUri": "https://orderdemo.iqmetrix.net",
+              "uri": "/v1/Companies(23813)/OrderFull?%24filter=PrintableId%20eq%20%27INKG5-2451%27",
+              "method": "GET",
+              "replyHeaders": {},
+              "statusCode": 200,
+              "responsePayload": [
+                {
+                  "Items": [
+                    {
+                      "ItemExtensions": [],
+                      "Id": "62b6fb5b-0124-4b34-a8ad-6ba37c652da0",
+                      "OrderId": "76f9ae59-b599-4515-93ee-6c684d1d2194",
+                      "ItemTypeId": 1,
+                      "ItemType": "DropShip",
+                      "ItemStatusId": 3,
+                      "ItemStatus": "Processed",
+                      "ProductId": "da15a758-5d7e-4619-8d61-13bce6311854",
+                      "SupplierEntityId": 7187,
+                      "Quantity": 1,
+                      "Cost": 0,
+                      "ListPrice": 0,
+                      "SellingPrice": 39.99,
+                      "Index": 0,
+                      "Description": "LG V20 3200 mAh Standard Battery",
+                      "SKU": "560532",
+                      "Notes": null,
+                      "SerialNumbers": [],
+                      "SupplierReference": null,
+                      "TrackingInformation": [],
+                      "ShippingOptionId": "21",
+                      "DeliveryRemarks": null,
+                      "DeliveryDate": null
+                    }
+                  ],
+                  "Id": "76f9ae59-b599-4515-93ee-6c684d1d2194",
+                  "OrderTypeId": 1,
+                  "OrderType": "Sales",
+                  "State": "Processed",
+                  "PrintableId": "S00000804",
+                  "Name": "S00000804",
+                  "TenderId": "S00000804",
+                  "TenderOrigin": null,
+                  "SourceId": null,
+                  "SourceName": null,
+                  "OrderReference": "5335670803356105603008",
+                  "EntityId": 131563,
+                  "ShippingEntityId": 0,
+                  "CustomerId": "00000000-0000-0000-0000-000000000000",
+                  "BillingCustomerId": "441c7001-56e4-4550-aae7-778094328359",
+                  "ShippingCustomerId": "441c7001-56e4-4550-aae7-778094328359",
+                  "ShippingAddressId": "ff0432d5-977a-4a83-a582-b8454b511236",
+                  "BillingAddressId": "ff0432d5-977a-4a83-a582-b8454b511236",
+                  "EmployeeId": 0,
+                  "DiscountCode": null,
+                  "DiscountDescription": null,
+                  "DiscountAmount": 0,
+                  "CreatedDateUtc": "2018-08-31T16:58:03.56Z",
+                  "OrderExpiryHours": 72,
+                  "OrderExpiryDate": "2018-09-03T16:58:03.56Z"
+                }
+              ]
             }
           ],
           "channelProfile": {
@@ -2150,7 +2214,8 @@
           "defaultHeaders": {},
           "links": [
             {
-              "uri": "/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09:59:59.999Z%20and%20updatedUtc%20lt%202017-05-12T12:00:00.001Z&page=1&pageSize=5",
+              "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net",
+              "uri": "/v1/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09%3A59%3A59.999Z%20and%20updatedUtc%20lt%202017-05-12T12%3A00%3A00.001Z&page=1&pageSize=5&sortBy=createdUtc&sortOrder=asc",
               "method": "GET",
               "replyHeaders": {},
               "statusCode": 200,
@@ -2187,6 +2252,7 @@
                 "startDateGMT": "2017-05-12T10:00:00.000Z",
                 "endDateGMT": "2017-05-12T12:00:00.000Z"
               },
+              "page": 1,
               "pageSize": 1
             }
           },
@@ -2194,210 +2260,8 @@
           "defaultHeaders": {},
           "links": [
             {
-              "uri": "/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09:59:59.999Z%20and%20updatedUtc%20lt%202017-05-12T12:00:00.001Z&pageSize=1",
-              "method": "GET",
-              "replyHeaders": {},
-              "statusCode": 200,
-              "responsePayload": {
-                "definition": {
-                  "id": "OrderList",
-                  "name": "Order List Report",
-                  "ownEntityPermission": "ViewOrderManagement",
-                  "anyEntityPermission": "ViewAllOrderManagement",
-                  "collection": "Order",
-                  "description": "View list of Platform orders.",
-                  "columns": [
-                    {
-                      "name": "Location",
-                      "key": "locationId"
-                    }
-                  ]
-                },
-                "rows": [
-                  {
-                    "_id": "58cad41cdc0db43a61eec9e4",
-                    "invoiceNumber": "INKG5-2498",
-                    "companyId": 14146,
-                    "locationId": 14202,
-                    "locationName": "Dufferin Mall",
-                    "customerName": "John Smith",
-                    "shippingEntityId": "0",
-                    "shippingEntityName": "Customer",
-                    "statusId": "0",
-                    "statusName": "Pending",
-                    "createdUtc": "2017-03-16T18:06:16.7950000Z"
-                  }
-                ],
-                "totalRecords": 2
-              }
-            },
-            {
-              "uri": "/Companies(23813)/OrderDetails(58cad41cdc0db43a61eec9e4)",
-              "method": "GET",
-              "replyHeaders": {},
-              "statusCode": 200,
-              "responsePayload": {
-                "id": "58c6f4bddc0db43a61ee98b5",
-                "invoiceNumber": "INKG5-2451",
-                "companyId": 14146,
-                "companyName": "Globex",
-                "locationId": 14202,
-                "locationName": "Dufferin Mall",
-                "customerName": "John Smith",
-                "shipToStore": false,
-                "shippingEntityId": "0",
-                "shippingEntityName": "Customer",
-                "statusId": "0",
-                "statusName": "Pending",
-                "billToAddress": {
-                  "crmId": "d2631c9d-0303-14b8-b328-16ac5e409fb2",
-                  "crmAddressId": "a5828b6c-13be-b07b-bebd-1060c72828fd",
-                  "customerName": "John Smith",
-                  "businessName": "",
-                  "streetAddress1": "349 W. Narwhal Lane",
-                  "streetAddress2": "Suite 400",
-                  "city": "Cypress",
-                  "postalCode": 55555,
-                  "region": "Texas",
-                  "regionCode": "TX",
-                  "country": "United States",
-                  "countryCode": "US",
-                  "email": "",
-                  "phone": "(555) 555-5556"
-                },
-                "shipToAddress": {
-                  "crmId": "d2631c9d-0303-14b8-b328-16ac5e409fb2",
-                  "crmAddressId": "a5828b6c-13be-b07b-bebd-1060c72828fd",
-                  "customerName": "John Smith",
-                  "businessName": "",
-                  "streetAddress1": "349 W. Narwhal Lane",
-                  "streetAddress2": "Suite 400",
-                  "city": "Cypress",
-                  "postalCode": 55555,
-                  "region": "Texas",
-                  "regionCode": "TX",
-                  "country": "United States",
-                  "countryCode": "US",
-                  "email": "",
-                  "phone": "(555) 555-5556"
-                },
-                "dropshipOrderItems": [
-                  {
-                    "dropshipOrderId": "9dd08bfc-24a0-99ed-64c4-8b5602402f91",
-                    "supplierId": 81553,
-                    "supplierName": "NOZAMA Inc.",
-                    "catalogItemId": "788b732b-16bd-9c19-7954-4e0eec524f65",
-                    "productName": "Motorola Droid Ultra Aegis Case - Trident Green",
-                    "supplierSku": "EKg-18-IAY",
-                    "quantity": 1,
-                    "sellingPrice": 34.95,
-                    "statusId": "0",
-                    "statusName": "Pending Supplier",
-                    "trackingNumber": "",
-                    "shippingProvider": "",
-                    "supplierMessage": "",
-                    "updatedUtc": "2017-03-13T19:36:26.2620000Z"
-                  }
-                ],
-                "createdUtc": "2017-03-16T18:06:16.7950000Z",
-                "updatedUtc": "2017-03-13T19:36:26.2620000Z"
-              }
-            },
-            {
-              "uri": "/Companies(23813)/OrderDetails(58cad41cdc0db43a61eec9e3)",
-              "method": "GET",
-              "replyHeaders": {},
-              "statusCode": 200,
-              "responsePayload": {
-                "id": "58c6f4bddc0db43a61ee98b5",
-                "invoiceNumber": "INKG5-2451",
-                "companyId": 14146,
-                "companyName": "Globex",
-                "locationId": 14202,
-                "locationName": "Dufferin Mall",
-                "customerName": "John Smith",
-                "shipToStore": false,
-                "shippingEntityId": "0",
-                "shippingEntityName": "Customer",
-                "statusId": "0",
-                "statusName": "Pending",
-                "billToAddress": {
-                  "crmId": "d2631c9d-0303-14b8-b328-16ac5e409fb2",
-                  "crmAddressId": "a5828b6c-13be-b07b-bebd-1060c72828fd",
-                  "customerName": "John Smith",
-                  "businessName": "",
-                  "streetAddress1": "349 W. Narwhal Lane",
-                  "streetAddress2": "Suite 400",
-                  "city": "Cypress",
-                  "postalCode": 55555,
-                  "region": "Texas",
-                  "regionCode": "TX",
-                  "country": "United States",
-                  "countryCode": "US",
-                  "email": "",
-                  "phone": "(555) 555-5556"
-                },
-                "shipToAddress": {
-                  "crmId": "d2631c9d-0303-14b8-b328-16ac5e409fb2",
-                  "crmAddressId": "a5828b6c-13be-b07b-bebd-1060c72828fd",
-                  "customerName": "John Smith",
-                  "businessName": "",
-                  "streetAddress1": "349 W. Narwhal Lane",
-                  "streetAddress2": "Suite 400",
-                  "city": "Cypress",
-                  "postalCode": 55555,
-                  "region": "Texas",
-                  "regionCode": "TX",
-                  "country": "United States",
-                  "countryCode": "US",
-                  "email": "",
-                  "phone": "(555) 555-5556"
-                },
-                "dropshipOrderItems": [
-                  {
-                    "dropshipOrderId": "9dd08bfc-24a0-99ed-64c4-8b5602402f91",
-                    "supplierId": 81553,
-                    "supplierName": "NOZAMA Inc.",
-                    "catalogItemId": "788b732b-16bd-9c19-7954-4e0eec524f65",
-                    "productName": "Motorola Droid Ultra Aegis Case - Trident Green",
-                    "supplierSku": "EKg-18-IAY",
-                    "quantity": 1,
-                    "sellingPrice": 34.95,
-                    "statusId": "0",
-                    "statusName": "Pending Supplier",
-                    "trackingNumber": "",
-                    "shippingProvider": "",
-                    "supplierMessage": "",
-                    "updatedUtc": "2017-03-13T19:36:26.2620000Z"
-                  }
-                ],
-                "createdUtc": "2017-03-16T18:06:16.7950000Z",
-                "updatedUtc": "2017-03-13T19:36:26.2620000Z"
-              }
-            }
-          ],
-          "channelProfile": {
-            "fulfillmentBusinessReferences": ["id"],
-            "salesOrderBusinessReferences": ["invoiceNumber"]
-          }
-        },
-        {
-          "ncStatusCode": 400,
-          "payload": {
-            "doc": {
-              "modifiedDateRange": {
-                "startDateGMT": "2017-05-12T10:00:00.000Z",
-                "endDateGMT": "2017-05-12T12:00:00.000Z"
-              },
-              "page": 1,
-              "pageSize": 5
-            }
-          },
-          "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net/v1",
-          "defaultHeaders": {},
-          "links": [
-            {
-              "uri": "/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09:59:59.999Z%20and%20updatedUtc%20lt%202017-05-12T12:00:00.001Z&page=1&pageSize=5",
+              "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net",
+              "uri": "/v1/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09%3A59%3A59.999Z%20and%20updatedUtc%20lt%202017-05-12T12%3A00%3A00.001Z&page=1&pageSize=1&sortBy=createdUtc&sortOrder=asc",
               "method": "GET",
               "replyHeaders": {},
               "statusCode": 200,
@@ -2431,14 +2295,171 @@
                     "createdUtc": "2017-03-16T18:06:16.7950000Z"
                   }
                 ],
-                "totalRecords": 1
+                "totalRecords": 2
               }
             },
             {
               "uri": "/Companies(23813)/OrderDetails(58cad41cdc0db43a61eec9e3)",
               "method": "GET",
               "replyHeaders": {},
-              "statusCode": 401,
+              "statusCode": 200,
+              "responsePayload": {
+                "id": "58c6f4bddc0db43a61ee98b5",
+                "invoiceNumber": "INKG5-2451",
+                "companyId": 14146,
+                "companyName": "Globex",
+                "locationId": 14202,
+                "locationName": "Dufferin Mall",
+                "customerName": "John Smith",
+                "shipToStore": false,
+                "shippingEntityId": "0",
+                "shippingEntityName": "Customer",
+                "statusId": "0",
+                "statusName": "Pending",
+                "billToAddress": {
+                  "crmId": "d2631c9d-0303-14b8-b328-16ac5e409fb2",
+                  "crmAddressId": "a5828b6c-13be-b07b-bebd-1060c72828fd",
+                  "customerName": "John Smith",
+                  "businessName": "",
+                  "streetAddress1": "349 W. Narwhal Lane",
+                  "streetAddress2": "Suite 400",
+                  "city": "Cypress",
+                  "postalCode": 55555,
+                  "region": "Texas",
+                  "regionCode": "TX",
+                  "country": "United States",
+                  "countryCode": "US",
+                  "email": "",
+                  "phone": "(555) 555-5556"
+                },
+                "shipToAddress": {
+                  "crmId": "d2631c9d-0303-14b8-b328-16ac5e409fb2",
+                  "crmAddressId": "a5828b6c-13be-b07b-bebd-1060c72828fd",
+                  "customerName": "John Smith",
+                  "businessName": "",
+                  "streetAddress1": "349 W. Narwhal Lane",
+                  "streetAddress2": "Suite 400",
+                  "city": "Cypress",
+                  "postalCode": 55555,
+                  "region": "Texas",
+                  "regionCode": "TX",
+                  "country": "United States",
+                  "countryCode": "US",
+                  "email": "",
+                  "phone": "(555) 555-5556"
+                },
+                "dropshipOrderItems": [
+                  {
+                    "dropshipOrderId": "9dd08bfc-24a0-99ed-64c4-8b5602402f91",
+                    "supplierId": 81553,
+                    "supplierName": "NOZAMA Inc.",
+                    "catalogItemId": "788b732b-16bd-9c19-7954-4e0eec524f65",
+                    "productName": "Motorola Droid Ultra Aegis Case - Trident Green",
+                    "supplierSku": "EKg-18-IAY",
+                    "quantity": 1,
+                    "sellingPrice": 34.95,
+                    "statusId": "0",
+                    "statusName": "Pending Supplier",
+                    "trackingNumber": "",
+                    "shippingProvider": "",
+                    "supplierMessage": "",
+                    "updatedUtc": "2017-03-13T19:36:26.2620000Z"
+                  }
+                ],
+                "createdUtc": "2017-03-16T18:06:16.7950000Z",
+                "updatedUtc": "2017-03-13T19:36:26.2620000Z"
+              }
+            },
+            {
+              "baseUri": "https://orderdemo.iqmetrix.net",
+              "uri": "/v1/Companies(23813)/OrderFull?%24filter=PrintableId%20eq%20%27INKG5-2451%27",
+              "method": "GET",
+              "replyHeaders": {},
+              "statusCode": 200,
+              "responsePayload": [
+                {
+                  "Items": [
+                    {
+                      "ItemExtensions": [],
+                      "Id": "62b6fb5b-0124-4b34-a8ad-6ba37c652da0",
+                      "OrderId": "76f9ae59-b599-4515-93ee-6c684d1d2194",
+                      "ItemTypeId": 1,
+                      "ItemType": "DropShip",
+                      "ItemStatusId": 3,
+                      "ItemStatus": "Processed",
+                      "ProductId": "da15a758-5d7e-4619-8d61-13bce6311854",
+                      "SupplierEntityId": 7187,
+                      "Quantity": 1,
+                      "Cost": 0,
+                      "ListPrice": 0,
+                      "SellingPrice": 39.99,
+                      "Index": 0,
+                      "Description": "LG V20 3200 mAh Standard Battery",
+                      "SKU": "560532",
+                      "Notes": null,
+                      "SerialNumbers": [],
+                      "SupplierReference": null,
+                      "TrackingInformation": [],
+                      "ShippingOptionId": "21",
+                      "DeliveryRemarks": null,
+                      "DeliveryDate": null
+                    }
+                  ],
+                  "Id": "76f9ae59-b599-4515-93ee-6c684d1d2194",
+                  "OrderTypeId": 1,
+                  "OrderType": "Sales",
+                  "State": "Processed",
+                  "PrintableId": "S00000804",
+                  "Name": "S00000804",
+                  "TenderId": "S00000804",
+                  "TenderOrigin": null,
+                  "SourceId": null,
+                  "SourceName": null,
+                  "OrderReference": "5335670803356105603008",
+                  "EntityId": 131563,
+                  "ShippingEntityId": 0,
+                  "CustomerId": "00000000-0000-0000-0000-000000000000",
+                  "BillingCustomerId": "441c7001-56e4-4550-aae7-778094328359",
+                  "ShippingCustomerId": "441c7001-56e4-4550-aae7-778094328359",
+                  "ShippingAddressId": "ff0432d5-977a-4a83-a582-b8454b511236",
+                  "BillingAddressId": "ff0432d5-977a-4a83-a582-b8454b511236",
+                  "EmployeeId": 0,
+                  "DiscountCode": null,
+                  "DiscountDescription": null,
+                  "DiscountAmount": 0,
+                  "CreatedDateUtc": "2018-08-31T16:58:03.56Z",
+                  "OrderExpiryHours": 72,
+                  "OrderExpiryDate": "2018-09-03T16:58:03.56Z"
+                }
+              ]
+            }
+          ],
+          "channelProfile": {
+            "fulfillmentBusinessReferences": ["id"],
+            "salesOrderBusinessReferences": ["invoiceNumber"]
+          }
+        },
+        {
+          "ncStatusCode": 400,
+          "payload": {
+            "doc": {
+              "modifiedDateRange": {
+                "startDateGMT": "2017-05-12T12:00:00.000Z",
+                "endDateGMT": "2017-05-12T12:00:00.000Z"
+              },
+              "page": 1,
+              "pageSize": 5
+            }
+          },
+          "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net/v1",
+          "defaultHeaders": {},
+          "links": [
+            {
+              "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net",
+              "uri": "/v1/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09%3A59%3A59.999Z%20and%20updatedUtc%20lt%202017-05-12T12%3A00%3A00.001Z&page=1&pageSize=5&sortBy=createdUtc&sortOrder=asc",
+              "method": "GET",
+              "replyHeaders": {},
+              "statusCode": 404,
               "responsePayload": {}
             }
           ],
@@ -2463,7 +2484,8 @@
           "defaultHeaders": {},
           "links": [
             {
-              "uri": "/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09:59:59.999Z%20and%20updatedUtc%20lt%202017-05-12T12:00:00.001Z&page=1&pageSize=5",
+              "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net",
+              "uri": "/v1/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09%3A59%3A59.999Z%20and%20updatedUtc%20lt%202017-05-12T12%3A00%3A00.001Z&page=1&pageSize=5&sortBy=createdUtc&sortOrder=asc",
               "method": "GET",
               "replyHeaders": {},
               "statusCode": 200,
@@ -2529,7 +2551,8 @@
           "defaultHeaders": {},
           "links": [
             {
-              "uri": "/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09:59:59.999Z%20and%20updatedUtc%20lt%202017-05-12T12:00:00.001Z&page=1&pageSize=5",
+              "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net",
+              "uri": "/v1/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09%3A59%3A59.999Z%20and%20updatedUtc%20lt%202017-05-12T12%3A00%3A00.001Z&page=1&pageSize=5&sortBy=createdUtc&sortOrder=asc",
               "method": "GET",
               "replyHeaders": {},
               "statusCode": 200,
@@ -2600,7 +2623,8 @@
           "defaultHeaders": {},
           "links": [
             {
-              "uri": "/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09:59:59.999Z%20and%20updatedUtc%20lt%202017-05-12T12:00:00.001Z&page=1&pageSize=5",
+              "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net",
+              "uri": "/v1/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09%3A59%3A59.999Z%20and%20updatedUtc%20lt%202017-05-12T12%3A00%3A00.001Z&page=1&pageSize=5&sortBy=createdUtc&sortOrder=asc",
               "method": "GET",
               "replyHeaders": {},
               "statusCode": 200,
@@ -2708,6 +2732,69 @@
                 "createdUtc": "2017-03-16T18:06:16.7950000Z",
                 "updatedUtc": "2017-03-13T19:36:26.2620000Z"
               }
+            },
+            {
+              "baseUri": "https://salesorderdemo.iqmetrix.net",
+              "uri": "/v1/Companies(23813)/PrintableId(INKG5-2451)",
+              "method": "GET",
+              "replyHeaders": {},
+              "statusCode": 200,
+              "responsePayload": {
+                "Id": "S00000804",
+                "SalesOrders": [
+                  {
+                    "Id": "70018308-b43f-4225-8ae5-97778b949e68",
+                    "DateCreatedUtc": "2018-08-06T14:51:15",
+                    "DateInsertedUtc": "2018-08-31T16:58:05.157",
+                    "DateUpdatedUtc": "2018-08-31T16:58:05.157",
+                    "CompanyId": 131523,
+                    "LocationId": 131563,
+                    "CustomerId": "441c7001-56e4-4550-aae7-778094328359",
+                    "ExpiryDateUtc": null,
+                    "Items": [
+                      {
+                        "LineNumber": 1,
+                        "ProductCatalogId": "da15a758-5d7e-4619-8d61-13bce6311854",
+                        "Quantity": 1,
+                        "Price": 39.99,
+                        "PricingTermId": null,
+                        "CorrelationId": "560532",
+                        "ItemType": "DropShip",
+                        "SupplierEntityId": 7187,
+                        "SerialNumber": null,
+                        "TaxLineItems": [
+                          {
+                            "TaxName": "SalesTax",
+                            "TaxableAmount": 39.99,
+                            "Rate": 0,
+                            "Tax": 0,
+                            "IqTaxServiceId": null
+                          }
+                        ]
+                      }
+                    ],
+                    "Payments": [
+                      {
+                        "Id": "0239dd79-de42-41c1-8553-deb920b58240",
+                        "AuthCode": null,
+                        "TransactionNumber": null,
+                        "Token": null,
+                        "Amount": 44.98,
+                        "PaymentMethodId": "00000000-0000-0000-0000-000000000000",
+                        "CorrelationId": null
+                      }
+                    ],
+                    "TaxCalculationResultId": "00000000-0000-0000-0000-000000000000",
+                    "BillingAddressId": "ff0432d5-977a-4a83-a582-b8454b511236",
+                    "ShippingAddressId": "ff0432d5-977a-4a83-a582-b8454b511236",
+                    "PrintableId": "S00000804",
+                    "DropshipOrderId": "76f9ae59-b599-4515-93ee-6c684d1d2194",
+                    "UserId": null,
+                    "ShippingLineItems": [],
+                    "DiscountLineItems": []
+                  }
+                ]
+              }
             }
           ],
           "channelProfile": {
@@ -2730,7 +2817,8 @@
           "defaultHeaders": {},
           "links": [
             {
-              "uri": "/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09:59:59.999Z%20and%20updatedUtc%20lt%202017-05-12T12:00:00.001Z&page=1&pageSize=5",
+              "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net",
+              "uri": "/v1/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09%3A59%3A59.999Z%20and%20updatedUtc%20lt%202017-05-12T12%3A00%3A00.001Z&page=1&pageSize=5&sortBy=createdUtc&sortOrder=asc",
               "method": "GET",
               "replyHeaders": {},
               "statusCode": 200,
@@ -2766,6 +2854,7 @@
                 "startDateGMT": "2017-05-12T10:00:00.000Z",
                 "endDateGMT": "2017-05-12T12:00:00.000Z"
               },
+              "page": 1,
               "pageSize": 1
             }
           },
@@ -2773,209 +2862,8 @@
           "defaultHeaders": {},
           "links": [
             {
-              "uri": "/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09:59:59.999Z%20and%20updatedUtc%20lt%202017-05-12T12:00:00.001Z&pageSize=1",
-              "method": "GET",
-              "replyHeaders": {},
-              "statusCode": 200,
-              "responsePayload": {
-                "definition": {
-                  "id": "OrderList",
-                  "name": "Order List Report",
-                  "ownEntityPermission": "ViewOrderManagement",
-                  "anyEntityPermission": "ViewAllOrderManagement",
-                  "collection": "Order",
-                  "description": "View list of Platform orders.",
-                  "columns": [
-                    {
-                      "name": "Location",
-                      "key": "locationId"
-                    }
-                  ]
-                },
-                "rows": [
-                  {
-                    "_id": "58cad41cdc0db43a61eec9e4",
-                    "invoiceNumber": "INKG5-2498",
-                    "companyId": 14146,
-                    "locationId": 14202,
-                    "locationName": "Dufferin Mall",
-                    "customerName": "John Smith",
-                    "shippingEntityId": "0",
-                    "shippingEntityName": "Customer",
-                    "statusId": "0",
-                    "statusName": "Pending",
-                    "createdUtc": "2017-03-16T18:06:16.7950000Z"
-                  }
-                ],
-                "totalRecords": 2
-              }
-            },
-            {
-              "uri": "/Companies(23813)/OrderDetails(58cad41cdc0db43a61eec9e4)",
-              "method": "GET",
-              "replyHeaders": {},
-              "statusCode": 200,
-              "responsePayload": {
-                "id": "58c6f4bddc0db43a61ee98b5",
-                "invoiceNumber": "INKG5-2451",
-                "companyId": 14146,
-                "companyName": "Globex",
-                "locationId": 14202,
-                "locationName": "Dufferin Mall",
-                "customerName": "John Smith",
-                "shipToStore": false,
-                "shippingEntityId": "0",
-                "shippingEntityName": "Customer",
-                "statusId": "0",
-                "statusName": "Pending",
-                "billToAddress": {
-                  "crmId": "d2631c9d-0303-14b8-b328-16ac5e409fb2",
-                  "crmAddressId": "a5828b6c-13be-b07b-bebd-1060c72828fd",
-                  "customerName": "John Smith",
-                  "businessName": "",
-                  "streetAddress1": "349 W. Narwhal Lane",
-                  "streetAddress2": "Suite 400",
-                  "city": "Cypress",
-                  "postalCode": 55555,
-                  "region": "Texas",
-                  "regionCode": "TX",
-                  "country": "United States",
-                  "countryCode": "US",
-                  "email": "",
-                  "phone": "(555) 555-5556"
-                },
-                "shipToAddress": {
-                  "crmId": "d2631c9d-0303-14b8-b328-16ac5e409fb2",
-                  "crmAddressId": "a5828b6c-13be-b07b-bebd-1060c72828fd",
-                  "customerName": "John Smith",
-                  "businessName": "",
-                  "streetAddress1": "349 W. Narwhal Lane",
-                  "streetAddress2": "Suite 400",
-                  "city": "Cypress",
-                  "postalCode": 55555,
-                  "region": "Texas",
-                  "regionCode": "TX",
-                  "country": "United States",
-                  "countryCode": "US",
-                  "email": "",
-                  "phone": "(555) 555-5556"
-                },
-                "dropshipOrderItems": [
-                  {
-                    "dropshipOrderId": "9dd08bfc-24a0-99ed-64c4-8b5602402f91",
-                    "supplierId": 81553,
-                    "supplierName": "NOZAMA Inc.",
-                    "catalogItemId": "788b732b-16bd-9c19-7954-4e0eec524f65",
-                    "productName": "Motorola Droid Ultra Aegis Case - Trident Green",
-                    "supplierSku": "EKg-18-IAY",
-                    "quantity": 1,
-                    "sellingPrice": 34.95,
-                    "statusId": "0",
-                    "statusName": "Pending Supplier",
-                    "trackingNumber": "",
-                    "shippingProvider": "",
-                    "supplierMessage": "",
-                    "updatedUtc": "2017-03-13T19:36:26.2620000Z"
-                  }
-                ],
-                "createdUtc": "2017-03-16T18:06:16.7950000Z",
-                "updatedUtc": "2017-03-13T19:36:26.2620000Z"
-              }
-            },
-            {
-              "uri": "/Companies(23813)/OrderDetails(58cad41cdc0db43a61eec9e3)",
-              "method": "GET",
-              "replyHeaders": {},
-              "statusCode": 200,
-              "responsePayload": {
-                "id": "58c6f4bddc0db43a61ee98b5",
-                "invoiceNumber": "INKG5-2451",
-                "companyId": 14146,
-                "companyName": "Globex",
-                "locationId": 14202,
-                "locationName": "Dufferin Mall",
-                "customerName": "John Smith",
-                "shipToStore": false,
-                "shippingEntityId": "0",
-                "shippingEntityName": "Customer",
-                "statusId": "0",
-                "statusName": "Pending",
-                "billToAddress": {
-                  "crmId": "d2631c9d-0303-14b8-b328-16ac5e409fb2",
-                  "crmAddressId": "a5828b6c-13be-b07b-bebd-1060c72828fd",
-                  "customerName": "John Smith",
-                  "businessName": "",
-                  "streetAddress1": "349 W. Narwhal Lane",
-                  "streetAddress2": "Suite 400",
-                  "city": "Cypress",
-                  "postalCode": 55555,
-                  "region": "Texas",
-                  "regionCode": "TX",
-                  "country": "United States",
-                  "countryCode": "US",
-                  "email": "",
-                  "phone": "(555) 555-5556"
-                },
-                "shipToAddress": {
-                  "crmId": "d2631c9d-0303-14b8-b328-16ac5e409fb2",
-                  "crmAddressId": "a5828b6c-13be-b07b-bebd-1060c72828fd",
-                  "customerName": "John Smith",
-                  "businessName": "",
-                  "streetAddress1": "349 W. Narwhal Lane",
-                  "streetAddress2": "Suite 400",
-                  "city": "Cypress",
-                  "postalCode": 55555,
-                  "region": "Texas",
-                  "regionCode": "TX",
-                  "country": "United States",
-                  "countryCode": "US",
-                  "email": "",
-                  "phone": "(555) 555-5556"
-                },
-                "dropshipOrderItems": [
-                  {
-                    "dropshipOrderId": "9dd08bfc-24a0-99ed-64c4-8b5602402f91",
-                    "supplierId": 81553,
-                    "supplierName": "NOZAMA Inc.",
-                    "catalogItemId": "788b732b-16bd-9c19-7954-4e0eec524f65",
-                    "productName": "Motorola Droid Ultra Aegis Case - Trident Green",
-                    "supplierSku": "EKg-18-IAY",
-                    "quantity": 1,
-                    "sellingPrice": 34.95,
-                    "statusId": "0",
-                    "statusName": "Pending Supplier",
-                    "trackingNumber": "",
-                    "shippingProvider": "",
-                    "supplierMessage": "",
-                    "updatedUtc": "2017-03-13T19:36:26.2620000Z"
-                  }
-                ],
-                "createdUtc": "2017-03-16T18:06:16.7950000Z",
-                "updatedUtc": "2017-03-13T19:36:26.2620000Z"
-              }
-            }
-          ],
-          "channelProfile": {
-            "paymentCaptureBusinessReferences": ["id"]
-          }
-        },
-        {
-          "ncStatusCode": 400,
-          "payload": {
-            "doc": {
-              "modifiedDateRange": {
-                "startDateGMT": "2017-05-12T10:00:00.000Z",
-                "endDateGMT": "2017-05-12T12:00:00.000Z"
-              },
-              "page": 1,
-              "pageSize": 5
-            }
-          },
-          "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net/v1",
-          "defaultHeaders": {},
-          "links": [
-            {
-              "uri": "/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09:59:59.999Z%20and%20updatedUtc%20lt%202017-05-12T12:00:00.001Z&page=1&pageSize=5",
+              "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net",
+              "uri": "/v1/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09%3A59%3A59.999Z%20and%20updatedUtc%20lt%202017-05-12T12%3A00%3A00.001Z&page=1&pageSize=1&sortBy=createdUtc&sortOrder=asc",
               "method": "GET",
               "replyHeaders": {},
               "statusCode": 200,
@@ -3009,14 +2897,170 @@
                     "createdUtc": "2017-03-16T18:06:16.7950000Z"
                   }
                 ],
-                "totalRecords": 1
+                "totalRecords": 2
               }
             },
             {
               "uri": "/Companies(23813)/OrderDetails(58cad41cdc0db43a61eec9e3)",
               "method": "GET",
               "replyHeaders": {},
-              "statusCode": 401,
+              "statusCode": 200,
+              "responsePayload": {
+                "id": "58c6f4bddc0db43a61ee98b5",
+                "invoiceNumber": "INKG5-2451",
+                "companyId": 14146,
+                "companyName": "Globex",
+                "locationId": 14202,
+                "locationName": "Dufferin Mall",
+                "customerName": "John Smith",
+                "shipToStore": false,
+                "shippingEntityId": "0",
+                "shippingEntityName": "Customer",
+                "statusId": "0",
+                "statusName": "Pending",
+                "billToAddress": {
+                  "crmId": "d2631c9d-0303-14b8-b328-16ac5e409fb2",
+                  "crmAddressId": "a5828b6c-13be-b07b-bebd-1060c72828fd",
+                  "customerName": "John Smith",
+                  "businessName": "",
+                  "streetAddress1": "349 W. Narwhal Lane",
+                  "streetAddress2": "Suite 400",
+                  "city": "Cypress",
+                  "postalCode": 55555,
+                  "region": "Texas",
+                  "regionCode": "TX",
+                  "country": "United States",
+                  "countryCode": "US",
+                  "email": "",
+                  "phone": "(555) 555-5556"
+                },
+                "shipToAddress": {
+                  "crmId": "d2631c9d-0303-14b8-b328-16ac5e409fb2",
+                  "crmAddressId": "a5828b6c-13be-b07b-bebd-1060c72828fd",
+                  "customerName": "John Smith",
+                  "businessName": "",
+                  "streetAddress1": "349 W. Narwhal Lane",
+                  "streetAddress2": "Suite 400",
+                  "city": "Cypress",
+                  "postalCode": 55555,
+                  "region": "Texas",
+                  "regionCode": "TX",
+                  "country": "United States",
+                  "countryCode": "US",
+                  "email": "",
+                  "phone": "(555) 555-5556"
+                },
+                "dropshipOrderItems": [
+                  {
+                    "dropshipOrderId": "9dd08bfc-24a0-99ed-64c4-8b5602402f91",
+                    "supplierId": 81553,
+                    "supplierName": "NOZAMA Inc.",
+                    "catalogItemId": "788b732b-16bd-9c19-7954-4e0eec524f65",
+                    "productName": "Motorola Droid Ultra Aegis Case - Trident Green",
+                    "supplierSku": "EKg-18-IAY",
+                    "quantity": 1,
+                    "sellingPrice": 34.95,
+                    "statusId": "0",
+                    "statusName": "Pending Supplier",
+                    "trackingNumber": "",
+                    "shippingProvider": "",
+                    "supplierMessage": "",
+                    "updatedUtc": "2017-03-13T19:36:26.2620000Z"
+                  }
+                ],
+                "createdUtc": "2017-03-16T18:06:16.7950000Z",
+                "updatedUtc": "2017-03-13T19:36:26.2620000Z"
+              }
+            },
+            {
+              "baseUri": "https://salesorderdemo.iqmetrix.net",
+              "uri": "/v1/Companies(23813)/PrintableId(INKG5-2451)",
+              "method": "GET",
+              "replyHeaders": {},
+              "statusCode": 200,
+              "responsePayload": {
+                "Id": "S00000804",
+                "SalesOrders": [
+                  {
+                    "Id": "70018308-b43f-4225-8ae5-97778b949e68",
+                    "DateCreatedUtc": "2018-08-06T14:51:15",
+                    "DateInsertedUtc": "2018-08-31T16:58:05.157",
+                    "DateUpdatedUtc": "2018-08-31T16:58:05.157",
+                    "CompanyId": 131523,
+                    "LocationId": 131563,
+                    "CustomerId": "441c7001-56e4-4550-aae7-778094328359",
+                    "ExpiryDateUtc": null,
+                    "Items": [
+                      {
+                        "LineNumber": 1,
+                        "ProductCatalogId": "da15a758-5d7e-4619-8d61-13bce6311854",
+                        "Quantity": 1,
+                        "Price": 39.99,
+                        "PricingTermId": null,
+                        "CorrelationId": "560532",
+                        "ItemType": "DropShip",
+                        "SupplierEntityId": 7187,
+                        "SerialNumber": null,
+                        "TaxLineItems": [
+                          {
+                            "TaxName": "SalesTax",
+                            "TaxableAmount": 39.99,
+                            "Rate": 0,
+                            "Tax": 0,
+                            "IqTaxServiceId": null
+                          }
+                        ]
+                      }
+                    ],
+                    "Payments": [
+                      {
+                        "Id": "0239dd79-de42-41c1-8553-deb920b58240",
+                        "AuthCode": null,
+                        "TransactionNumber": null,
+                        "Token": null,
+                        "Amount": 44.98,
+                        "PaymentMethodId": "00000000-0000-0000-0000-000000000000",
+                        "CorrelationId": null
+                      }
+                    ],
+                    "TaxCalculationResultId": "00000000-0000-0000-0000-000000000000",
+                    "BillingAddressId": "ff0432d5-977a-4a83-a582-b8454b511236",
+                    "ShippingAddressId": "ff0432d5-977a-4a83-a582-b8454b511236",
+                    "PrintableId": "S00000804",
+                    "DropshipOrderId": "76f9ae59-b599-4515-93ee-6c684d1d2194",
+                    "UserId": null,
+                    "ShippingLineItems": [],
+                    "DiscountLineItems": []
+                  }
+                ]
+              }
+            }
+          ],
+          "channelProfile": {
+            "paymentCaptureBusinessReferences": ["id"]
+          }
+        },
+        {
+          "ncStatusCode": 400,
+          "payload": {
+            "doc": {
+              "modifiedDateRange": {
+                "startDateGMT": "2017-05-12T12:00:00.000Z",
+                "endDateGMT": "2017-05-12T12:00:00.000Z"
+              },
+              "page": 1,
+              "pageSize": 5
+            }
+          },
+          "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net/v1",
+          "defaultHeaders": {},
+          "links": [
+            {
+              "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net",
+              "uri": "/v1/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09%3A59%3A59.999Z%20and%20updatedUtc%20lt%202017-05-12T12%3A00%3A00.001Z&page=1&pageSize=5&sortBy=createdUtc&sortOrder=asc",
+              "method": "GET",
+              "replyHeaders": {},
+              "statusCode": 404,
               "responsePayload": {}
             }
           ],
@@ -3040,7 +3084,8 @@
           "defaultHeaders": {},
           "links": [
             {
-              "uri": "/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09:59:59.999Z%20and%20updatedUtc%20lt%202017-05-12T12:00:00.001Z&page=1&pageSize=5",
+              "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net",
+              "uri": "/v1/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09%3A59%3A59.999Z%20and%20updatedUtc%20lt%202017-05-12T12%3A00%3A00.001Z&page=1&pageSize=5&sortBy=createdUtc&sortOrder=asc",
               "method": "GET",
               "replyHeaders": {},
               "statusCode": 200,
@@ -3105,7 +3150,8 @@
           "defaultHeaders": {},
           "links": [
             {
-              "uri": "/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09:59:59.999Z%20and%20updatedUtc%20lt%202017-05-12T12:00:00.001Z&page=1&pageSize=5",
+              "baseUri": "https://ordermanagementreportingdemo.iqmetrix.net",
+              "uri": "/v1/Reports/OrderList/report?filter=companyId%20eq%2023813%20and%20updatedUtc%20gt%202017-05-12T09%3A59%3A59.999Z%20and%20updatedUtc%20lt%202017-05-12T12%3A00%3A00.001Z&page=1&pageSize=5&sortBy=createdUtc&sortOrder=asc",
               "method": "GET",
               "replyHeaders": {},
               "statusCode": 200,

--- a/functions/GetFulfillmentFromQuery.js
+++ b/functions/GetFulfillmentFromQuery.js
@@ -1,327 +1,263 @@
-'use strict'
-const nc = require("./util/ncUtils");
+module.exports.GetFulfillmentFromQuery = (ncUtil, channelProfile, flowContext, payload, callback) => {
+  const stubName = "GetFulfillmentFromQuery";
+  const referenceLocations = ["fulfillmentBusinessReferences", "salesOrderBusinessReferences"];
+  const nc = require("./util/ncUtils");
+  let companyId, page, pageSize, totalResults;
+  const stub = new nc.Stub(stubName, referenceLocations, ncUtil, channelProfile, flowContext, payload, callback);
 
-let GetFulfillmentFromQuery = function (ncUtil, channelProfile, flowContext, payload, callback) {
-
-  log("Building response object...", ncUtil);
-  let out = {
-    ncStatusCode: null,
-    response: {},
-    payload: {}
-  };
-
-  let invalid = false;
-  let invalidMsg = "";
-
-  //If ncUtil does not contain a request object, the request can't be sent
-  if (!ncUtil) {
-    invalid = true;
-    invalidMsg = "ncUtil was not provided"
-  }
-
-  //If channelProfile does not contain channelSettingsValues, channelAuthValues or fulfillmentBusinessReferences, the request can't be sent
-  if (!channelProfile) {
-    invalid = true;
-    invalidMsg = "channelProfile was not provided"
-  } else if (!channelProfile.channelSettingsValues) {
-    invalid = true;
-    invalidMsg = "channelProfile.channelSettingsValues was not provided"
-  } else if (!channelProfile.channelSettingsValues.protocol) {
-    invalid = true;
-    invalidMsg = "channelProfile.channelSettingsValues.protocol was not provided"
-  } else if (!channelProfile.channelSettingsValues.environment) {
-    invalid = true;
-    invalidMsg = "channelProfile.channelSettingsValues.environment was not provided"
-  } else if (!channelProfile.channelAuthValues) {
-    invalid = true;
-    invalidMsg = "channelProfile.channelAuthValues was not provided"
-  } else if (!channelProfile.channelAuthValues.access_token) {
-    invalid = true;
-    invalidMsg = "channelProfile.channelAuthValues.access_token was not provided"
-  } else if (!channelProfile.channelAuthValues.company_id) {
-    invalid = true;
-    invalidMsg = "channelProfile.channelAuthValues.company_id was not provided"
-  } else if (!channelProfile.fulfillmentBusinessReferences) {
-    invalid = true;
-    invalidMsg = "channelProfile.fulfillmentBusinessReferences was not provided"
-  } else if (!Array.isArray(channelProfile.fulfillmentBusinessReferences)) {
-    invalid = true;
-    invalidMsg = "channelProfile.fulfillmentBusinessReferences is not an array"
-  } else if (channelProfile.fulfillmentBusinessReferences.length === 0) {
-    invalid = true;
-    invalidMsg = "channelProfile.fulfillmentBusinessReferences is empty"
-  } else if (!channelProfile.salesOrderBusinessReferences) {
-    invalid = true;
-    invalidMsg = "channelProfile.salesOrderBusinessReferences was not provided"
-  } else if (!Array.isArray(channelProfile.salesOrderBusinessReferences)) {
-    invalid = true;
-    invalidMsg = "channelProfile.salesOrderBusinessReferences is not an array"
-  } else if (channelProfile.salesOrderBusinessReferences.length === 0) {
-    invalid = true;
-    invalidMsg = "channelProfile.salesOrderBusinessReferences is empty"
-  }
-
-  //If a fulfillment document was not passed in, the request is invalid
-  if (!payload) {
-    invalid = true;
-    invalidMsg = "payload was not provided"
-  } else if (!payload.doc) {
-    invalid = true;
-    invalidMsg = "payload.doc was not provided";
-  } else if (!payload.doc.remoteIDs && !payload.doc.searchFields && !payload.doc.modifiedDateRange) {
-    invalid = true;
-    invalidMsg = "either payload.doc.remoteIDs or payload.doc.searchFields or payload.doc.modifiedDateRange must be provided"
-  } else if (payload.doc.remoteIDs && (payload.doc.searchFields || payload.doc.modifiedDateRange)) {
-    invalid = true;
-    invalidMsg = "only one of payload.doc.remoteIDs or payload.doc.searchFields or payload.doc.modifiedDateRange may be provided"
-  } else if (payload.doc.remoteIDs && (!Array.isArray(payload.doc.remoteIDs) || payload.doc.remoteIDs.length === 0)) {
-    invalid = true;
-    invalidMsg = "payload.doc.remoteIDs must be an Array with at least 1 remoteID"
-  } else if (payload.doc.searchFields && (!Array.isArray(payload.doc.searchFields) || payload.doc.searchFields.length === 0)) {
-    invalid = true;
-    invalidMsg = "payload.doc.searchFields must be an Array with at least 1 key value pair: {searchField: 'key', searchValues: ['value_1']}"
-  } else if (payload.doc.searchFields) {
-    for (let i = 0; i < payload.doc.searchFields.length; i++) {
-      if (!payload.doc.searchFields[i].searchField || !Array.isArray(payload.doc.searchFields[i].searchValues) || payload.doc.searchFields[i].searchValues.length === 0) {
-        invalid = true;
-        invalidMsg = "payload.doc.searchFields[" + i + "] must be a key value pair: {searchField: 'key', searchValues: ['value_1']}";
-        break;
-      }
-    }
-  } else if (payload.doc.modifiedDateRange && !(payload.doc.modifiedDateRange.startDateGMT || payload.doc.modifiedDateRange.endDateGMT)) {
-    invalid = true;
-    invalidMsg = "at least one of payload.doc.modifiedDateRange.startDateGMT or payload.doc.modifiedDateRange.endDateGMT must be provided"
-  } else if (payload.doc.modifiedDateRange && payload.doc.modifiedDateRange.startDateGMT && payload.doc.modifiedDateRange.endDateGMT && (payload.doc.modifiedDateRange.startDateGMT > payload.doc.modifiedDateRange.endDateGMT)) {
-    invalid = true;
-    invalidMsg = "startDateGMT must have a date before endDateGMT";
-  }
-
-  //If callback is not a function
-  if (!callback) {
-    throw new Error("A callback function was not provided");
-  } else if (typeof callback !== 'function') {
-    throw new TypeError("callback is not a function")
-  }
-
-  if (!invalid) {
-    let request = require('request');
-
-    let url = `${channelProfile.channelSettingsValues.protocol}://ordermanagementreporting${channelProfile.channelSettingsValues.environment}.iqmetrix.net/v1`;
-
-    /*
-     Create query string for searching orders by specific fields
-     */
-    let queryParams = [];
-    let filterParams = [];
-    let uris = [];
-
-    if (payload.doc.searchFields) {
-
-      let fields = [];
-      payload.doc.searchFields.forEach(function(searchField) {
-          // Loop through each value
-          let values = [];
-          searchField.searchValues.forEach(function(searchValue) {
-              values.push(searchField.searchField + " eq '" + encodeURIComponent(searchValue) + "'");
-          });
-          fields.push(values);
-      });
-
-      let endpoints = fieldsArray(fields);
-      endpoints.forEach(function(endpoint) {
-        uris.push("/Reports/OrderList/report?filter=companyId eq " + channelProfile.channelAuthValues.company_id + " and " + endpoint);
-      });
-
-      function fieldsArray(array) {
-          if (array.length == 1) {
-              return array[0];
-          } else {
-              let result = [];
-              let remainingFields = fieldsArray(array.slice(1));
-              for (var i = 0; i < remainingFields.length; i++) {
-                  for (var j = 0; j < array[0].length; j++) {
-                      result.push(array[0][j] + ' and '+ remainingFields[i]);
-                  }
-              }
-              return result;
-          }
-      }
-
-    } else if (payload.doc.remoteIDs) {
-      /*
-       Add remote IDs as a query parameter
-       */
-      payload.doc.remoteIDs.forEach((remoteID) => {
-         let endpoint = "/Reports/OrderList/report?filter=companyId eq " + channelProfile.channelAuthValues.company_id + " and id eq " + remoteID;
-         uris.push(endpoint);
-      });
-
-    } else if (payload.doc.modifiedDateRange) {
-      /*
-       Add modified date ranges to the query
-       iQmetrix only supports exclusive compare operator so skew each by 1 ms to create an equivalent inclusive range
-       */
-      if (payload.doc.modifiedDateRange.startDateGMT) {
-        filterParams.push("updatedUtc gt " + new Date(Date.parse(payload.doc.modifiedDateRange.startDateGMT) - 1).toISOString());
-      }
-      if (payload.doc.modifiedDateRange.endDateGMT) {
-        filterParams.push("updatedUtc lt " + new Date(Date.parse(payload.doc.modifiedDateRange.endDateGMT) + 1).toISOString());
-      }
-
-      let endpoint = "/Reports/OrderList/report?filter=companyId eq " + channelProfile.channelAuthValues.company_id + " and " + filterParams.join(' and ');
-      uris.push(endpoint);
-    }
-
-    /*
-     Add page to the query
-     */
-    if (payload.doc.page) {
-      queryParams.push("&page=" + payload.doc.page);
-    }
-
-    /*
-     Add pageSize to the query
-     */
-    if (payload.doc.pageSize) {
-      queryParams.push("&pageSize=" + payload.doc.pageSize);
-    }
-
-    uris.forEach(function(uri) {
-      // Add the authorization header
-      let headers = {
-          "Authorization": "Bearer " + channelProfile.channelAuthValues.access_token
-      };
-
-      /*
-       Set URL and headers
-       */
-      let options = {
-          url: url + uri + queryParams.join(''),
-          headers: headers,
-          json: true
-      };
-
-      log("Using URL [" + url + uri + queryParams.join('') + "]", ncUtil);
-
-      // Pass in our URL and headers
-      request(options, async function (error, response, body) {
-        try {
-          if (!error) {
-            console.log(body);
-            log("Do GetFulfillmentFromQuery Callback", ncUtil);
-            out.response.endpointStatusCode = response.statusCode;
-            out.response.endpointStatusMessage = response.statusMessage;
-
-            if (response.statusCode === 200 && body.rows.length > 0) {
-              if (body.rows.length < body.totalRecords) {
-                out.ncStatusCode = 206;
-              } else {
-                out.ncStatusCode = 200;
-              }
-
-              //For each order, get the order detail (i.e. fulfillment)
-              let fulfillmentPromises = body.rows.map((order) => {
-                let fulfillment = {
-                  response: {}
-                };
-
-                let endPoint = "/Companies(" + channelProfile.channelAuthValues.company_id + ")/OrderDetails(" + order._id + ")";
-                let url = `${channelProfile.channelSettingsValues.protocol}://ordermanagementreporting${channelProfile.channelSettingsValues.environment}.iqmetrix.net/v1${endPoint}`;
-                options.url = url;
-
-                log("Using URL [" + url + "]", ncUtil);
-
-                return new Promise((resolve, reject) => {
-                  try {
-                    request(options, function (error, response, body) {
-                      if (!error) {
-                        fulfillment.response.endpointStatusCode = response.statusCode;
-                        fulfillment.response.endpointStatusMessage = response.statusMessage;
-
-                        if (response.statusCode === 200) {
-                          fulfillment.ncStatusCode = 200;
-                          fulfillment.doc = body;
-                          fulfillment.fulfillmentRemoteID = body.id;
-                          fulfillment.fulfillmentBusinessReference = nc.extractBusinessReferences(channelProfile.fulfillmentBusinessReferences, body);
-                          fulfillment.salesOrderRemoteID = body.dropshipOrderItems[0].dropshipOrderId;
-                          fulfillment.salesOrderBusinessReference = nc.extractBusinessReferences(channelProfile.salesOrderBusinessReferences, body);
-
-                        } else if (response.statusCode === 429) {
-                          fulfillment.ncStatusCode = 429;
-                          fulfillment.error = body;
-                        } else if (response.statusCode === 500) {
-                          fulfillment.ncStatusCode = 500;
-                          fulfillment.error = body;
-                        } else {
-                          fulfillment.ncStatusCode = 400;
-                          fulfillment.error = body;
-                        }
-                      } else {
-                        logError("Do GetFulfillmentFromQuery Callback error - " + error, ncUtil);
-                        fulfillment.error = error;
-                        fulfillment.ncStatusCode = 500;
-                      }
-
-                      resolve(fulfillment);
-                    });
-                  } catch (err) {
-                    let rej = {payload: {}};
-                    rej.ncStatusCode = 500;
-                    rej.payload.error = {err: err, stack: err.stackTrace};
-                    reject(rej);
-                  }
-                });
-              });
-
-              try {
-                out.payload = await Promise.all(fulfillmentPromises);
-              } catch (rejected) {
-                out.ncStatusCode = rejected.ncStatusCode;
-                out.payload = rejected.payload;
-              }
-
-            } else if (response.statusCode === 200) {
-              out.ncStatusCode = 204;
-            } else if (response.statusCode === 429) {
-              out.ncStatusCode = 429;
-              out.payload.error = body;
-            } else if (response.statusCode === 500) {
-              out.ncStatusCode = 500;
-              out.payload.error = body;
-            } else {
-              out.ncStatusCode = 400;
-              out.payload.error = body;
-            }
-
-            callback(out);
-          } else {
-            logError("Do GetFulfillmentFromQuery Callback error - " + error, ncUtil);
-            out.payload.error = error;
-            out.ncStatusCode = 500;
-            callback(out);
-          }
-        } catch (err) {
-          logError("Exception occurred in GetFulfillmentFromQuery - " + err, ncUtil);
-          out.payload.error = {err: err, stack: err.stackTrace};
-          out.ncStatusCode = 500;
-          callback(out);
-        }
+  initializeStubFunction()
+    .then(searchForOrders)
+    .then(buildResponseObject)
+    .catch(handleError)
+    .then(() => callback(stub.out))
+    .catch(error => {
+      logError(`The callback function threw an exception: ${error}`);
+      setTimeout(() => {
+        throw error;
       });
     });
-  } else {
-    log("Callback with an invalid request - " + invalidMsg, ncUtil);
-    out.ncStatusCode = 400;
-    out.payload.error = invalidMsg;
-    callback(out);
+
+  async function initializeStubFunction() {
+    if (!stub.isValid) {
+      stub.messages.forEach(msg => logError(msg));
+      stub.out.ncStatusCode = 400;
+      throw new Error(`Invalid request [${stub.messages.join(" ")}]`);
+    }
+
+    logInfo("Stub function is valid.");
+
+    companyId = stub.channelProfile.channelAuthValues.company_id;
+    page = stub.payload.doc.page;
+    pageSize = stub.payload.doc.pageSize;
+
+    return JSON.parse(JSON.stringify(stub.payload.doc));
+  }
+
+  async function searchForOrders(queryDoc) {
+    const filters = [`companyId eq ${companyId}`];
+    let orders = [];
+
+    switch (stub.queryType) {
+      case "remoteIDs": {
+        orders = await remoteIdSearch(queryDoc.remoteIDs);
+        break;
+      }
+
+      case "createdDateRange": {
+        filters.push(`createdUtc gt ${new Date(Date.parse(queryDoc.createdDateRange.startDateGMT) - 1).toISOString()}`);
+        filters.push(`createdUtc lt ${new Date(Date.parse(queryDoc.createdDateRange.endDateGMT) + 1).toISOString()}`);
+        orders = await dateRangeSearch(filters);
+        break;
+      }
+
+      case "modifiedDateRange": {
+        filters.push(
+          `updatedUtc gt ${new Date(Date.parse(queryDoc.modifiedDateRange.startDateGMT) - 1).toISOString()}`
+        );
+        filters.push(`updatedUtc lt ${new Date(Date.parse(queryDoc.modifiedDateRange.endDateGMT) + 1).toISOString()}`);
+        orders = await dateRangeSearch(filters);
+        break;
+      }
+
+      default: {
+        stub.out.ncStatusCode = 400;
+        throw new Error(`Invalid request, unknown query type: '${stub.queryType}'`);
+      }
+    }
+    return orders;
+  }
+
+  async function remoteIdSearch(remoteIds) {
+    remoteIds = [...new Set(remoteIds)];
+    totalResults = remoteIds.length;
+    const startIndex = (page - 1) * pageSize;
+    const endIndex = page * pageSize;
+    const orders = [];
+    for (const remoteId of remoteIds.slice(startIndex, endIndex)) {
+      const order = await getOrderDetail(remoteId);
+      order.orderFull = await getOrderFull(order.invoiceNumber);
+      orders.push(order);
+    }
+    return orders;
+  }
+
+  async function dateRangeSearch(filters) {
+    const orderReport = await getOrderReport(filters);
+    totalResults = orderReport.totalRecords;
+    const orders = [];
+    for (const row of orderReport.rows) {
+      const order = await getOrderDetail(row._id);
+      order.orderFull = await getOrderFull(order.invoiceNumber);
+      orders.push(order);
+    }
+    return orders;
+  }
+
+  async function getOrderReport(filters) {
+    const filter = filters.join(" and ");
+    logInfo(`Getting order report with filter: '${filter}'`);
+
+    const req = stub.requestPromise.get(
+      Object.assign({}, stub.requestDefaults, {
+        method: "GET",
+        baseUrl: stub.getBaseUrl("ordermanagementreporting"),
+        url: "/v1/Reports/OrderList/report",
+        qs: {
+          filter: filter,
+          page: page,
+          pageSize: pageSize,
+          sortBy: "createdUtc",
+          sortOrder: "asc"
+        }
+      })
+    );
+    logInfo(`Calling: ${req.method} ${req.uri.href}`);
+
+    const resp = await req;
+    stub.out.response.endpointStatusCode = resp.statusCode;
+    stub.out.response.endpointStatusMessage = resp.statusMessage;
+
+    if (resp.timingPhases) {
+      logInfo(`Order report request completed in ${Math.round(resp.timingPhases.total)} milliseconds.`);
+    }
+
+    if (!resp.body || !nc.isArray(resp.body.rows) || !nc.isNumber(resp.body.totalRecords)) {
+      throw new TypeError(
+        "Order report response is not in expected format, expected rows[] and totalRecords properties."
+      );
+    }
+
+    logInfo(`Order report response contains ${resp.body.rows.length} of ${resp.body.totalRecords} records.`);
+
+    return resp.body;
+  }
+
+  async function getOrderDetail(orderId) {
+    logInfo(`Getting order detail for order '${orderId}'`);
+
+    const req = stub.requestPromise.get(
+      Object.assign({}, stub.requestDefaults, {
+        method: "GET",
+        baseUrl: stub.getBaseUrl("ordermanagementreporting"),
+        url: `/v1/Companies(${companyId})/OrderDetails(${orderId})`
+      })
+    );
+    logInfo(`Calling: ${req.method} ${req.uri.href}`);
+
+    const resp = await req;
+    stub.out.response.endpointStatusCode = resp.statusCode;
+    stub.out.response.endpointStatusMessage = resp.statusMessage;
+
+    if (resp.timingPhases) {
+      logInfo(`Order detail request completed in ${Math.round(resp.timingPhases.total)} milliseconds.`);
+    }
+
+    if (!resp.body || !resp.body.id || !resp.body.invoiceNumber) {
+      throw new TypeError("Order detail response is not in expected format, expected id and invoiceNumber properties.");
+    }
+
+    return resp.body;
+  }
+
+  async function getOrderFull(orderId) {
+    logInfo(`Getting order full details for order '${orderId}'`);
+
+    const req = stub.requestPromise.get(
+      Object.assign({}, stub.requestDefaults, {
+        method: "GET",
+        baseUrl: stub.getBaseUrl("order"),
+        url: `/v1/Companies(${companyId})/OrderFull`,
+        qs: {
+          $filter: `PrintableId eq '${orderId}'`
+        }
+      })
+    );
+    logInfo(`Calling: ${req.method} ${req.uri.href}`);
+
+    const resp = await req;
+    stub.out.response.endpointStatusCode = resp.statusCode;
+    stub.out.response.endpointStatusMessage = resp.statusMessage;
+
+    if (resp.timingPhases) {
+      logInfo(`Order full details request completed in ${Math.round(resp.timingPhases.total)} milliseconds.`);
+    }
+
+    if (!nc.isArray(resp.body) || resp.body.length > 1) {
+      throw new TypeError(
+        "Order full details response is not in expected format, expected an array with 1 or 0 objects."
+      );
+    }
+
+    if (resp.body.length === 0) {
+      throw new TypeError("Order full details response did not contain any results.");
+    }
+
+    if (resp.body.length > 1) {
+      throw new TypeError("Order full details response contains multiple results.");
+    }
+
+    return resp.body[0];
+  }
+
+  async function buildResponseObject(orderFulfillments) {
+    if (orderFulfillments.length > 0) {
+      logInfo(`Submitting ${orderFulfillments.length} order fulfillments...`);
+
+      stub.out.payload = [];
+      orderFulfillments.forEach(orderFulfillment => {
+        stub.out.payload.push({
+          doc: orderFulfillment,
+          fulfillmentRemoteID: orderFulfillment.id,
+          fulfillmentBusinessReference: nc.extractBusinessReferences(
+            stub.channelProfile.fulfillmentBusinessReferences,
+            orderFulfillment
+          ),
+          salesOrderRemoteID: orderFulfillment.dropshipOrderItems[0].dropshipOrderId,
+          salesOrderBusinessReference: nc.extractBusinessReferences(
+            stub.channelProfile.salesOrderBusinessReferences,
+            orderFulfillment
+          )
+        });
+      });
+
+      stub.out.ncStatusCode = page * pageSize <= totalResults ? 206 : 200;
+    } else {
+      logInfo("No order fulfillments found.");
+      stub.out.ncStatusCode = 204;
+    }
+
+    return stub.out;
+  }
+
+  async function handleError(error) {
+    logError(error);
+    if (error.name === "StatusCodeError") {
+      stub.out.response.endpointStatusCode = error.statusCode;
+      stub.out.response.endpointStatusMessage = error.message;
+
+      if (error.statusCode >= 500) {
+        stub.out.ncStatusCode = 500;
+      } else if ([429, 401].includes(error.statusCode)) {
+        stub.out.ncStatusCode = error.statusCode;
+      } else {
+        stub.out.ncStatusCode = 400;
+      }
+    }
+    stub.out.payload.error = error;
+    stub.out.ncStatusCode = stub.out.ncStatusCode || 500;
+
+    return stub.out;
+  }
+
+  function logInfo(msg) {
+    stub.log(msg, "info");
+  }
+
+  function logWarn(msg) {
+    stub.log(msg, "warn");
+  }
+
+  function logError(msg) {
+    stub.log(msg, "error");
   }
 };
-
-function logError(msg, ncUtil) {
-  console.log("[error] " + msg);
-}
-
-function log(msg, ncUtil) {
-  console.log("[info] " + msg);
-}
-
-module.exports.GetFulfillmentFromQuery = GetFulfillmentFromQuery;

--- a/functions/GetPaymentCaptureFromQuery.js
+++ b/functions/GetPaymentCaptureFromQuery.js
@@ -1,284 +1,255 @@
-'use strict'
-const nc = require("./util/ncUtils");
+module.exports.GetPaymentCaptureFromQuery = (ncUtil, channelProfile, flowContext, payload, callback) => {
+  const stubName = "GetPaymentCaptureFromQuery";
+  const referenceLocations = ["paymentCaptureBusinessReferences"];
+  const nc = require("./util/ncUtils");
+  let companyId, page, pageSize, totalResults;
+  const stub = new nc.Stub(stubName, referenceLocations, ncUtil, channelProfile, flowContext, payload, callback);
 
-let GetPaymentCaptureFromQuery = function (ncUtil, channelProfile, flowContext, payload, callback) {
-
-  log("Building response object...", ncUtil);
-  let out = {
-    ncStatusCode: null,
-    response: {},
-    payload: {}
-  };
-
-  let invalid = false;
-  let invalidMsg = "";
-
-  //If ncUtil does not contain a request object, the request can't be sent
-  if (!ncUtil) {
-    invalid = true;
-    invalidMsg = "ncUtil was not provided"
-  }
-
-  //If channelProfile does not contain channelSettingsValues, channelAuthValues or paymentCaptureBusinessReferences, the request can't be sent
-  if (!channelProfile) {
-    invalid = true;
-    invalidMsg = "channelProfile was not provided"
-  } else if (!channelProfile.channelSettingsValues) {
-    invalid = true;
-    invalidMsg = "channelProfile.channelSettingsValues was not provided"
-  } else if (!channelProfile.channelSettingsValues.protocol) {
-    invalid = true;
-    invalidMsg = "channelProfile.channelSettingsValues.protocol was not provided"
-  } else if (!channelProfile.channelSettingsValues.environment) {
-    invalid = true;
-    invalidMsg = "channelProfile.channelSettingsValues.environment was not provided"
-  } else if (!channelProfile.channelAuthValues) {
-    invalid = true;
-    invalidMsg = "channelProfile.channelAuthValues was not provided"
-  } else if (!channelProfile.channelAuthValues.access_token) {
-    invalid = true;
-    invalidMsg = "channelProfile.channelAuthValues.access_token was not provided"
-  } else if (!channelProfile.channelAuthValues.company_id) {
-    invalid = true;
-    invalidMsg = "channelProfile.channelAuthValues.company_id was not provided"
-  } else if (!channelProfile.paymentCaptureBusinessReferences) {
-    invalid = true;
-    invalidMsg = "channelProfile.paymentCaptureBusinessReferences was not provided"
-  } else if (!Array.isArray(channelProfile.paymentCaptureBusinessReferences)) {
-    invalid = true;
-    invalidMsg = "channelProfile.paymentCaptureBusinessReferences is not an array"
-  } else if (channelProfile.paymentCaptureBusinessReferences.length === 0) {
-    invalid = true;
-    invalidMsg = "channelProfile.paymentCaptureBusinessReferences is empty"
-  }
-
-  //If a paymentCapture document was not passed in, the request is invalid
-  if (!payload) {
-    invalid = true;
-    invalidMsg = "payload was not provided"
-  } else if (!payload.doc) {
-    invalid = true;
-    invalidMsg = "payload.doc was not provided";
-  } else if (!payload.doc.remoteIDs && !payload.doc.searchFields && !payload.doc.modifiedDateRange) {
-    invalid = true;
-    invalidMsg = "either payload.doc.remoteIDs or payload.doc.searchFields or payload.doc.modifiedDateRange must be provided"
-  } else if (payload.doc.remoteIDs && (payload.doc.searchFields || payload.doc.modifiedDateRange)) {
-    invalid = true;
-    invalidMsg = "only one of payload.doc.remoteIDs or payload.doc.searchFields or payload.doc.modifiedDateRange may be provided"
-  } else if (payload.doc.remoteIDs && (!Array.isArray(payload.doc.remoteIDs) || payload.doc.remoteIDs.length === 0)) {
-    invalid = true;
-    invalidMsg = "payload.doc.remoteIDs must be an Array with at least 1 remoteID"
-  } else if (payload.doc.searchFields && (!Array.isArray(payload.doc.searchFields) || payload.doc.searchFields.length === 0)) {
-    invalid = true;
-    invalidMsg = "payload.doc.searchFields must be an Array with at least 1 key value pair: {searchField: 'key', searchValues: ['value_1']}"
-  } else if (payload.doc.searchFields) {
-    for (let i = 0; i < payload.doc.searchFields.length; i++) {
-      if (!payload.doc.searchFields[i].searchField || !Array.isArray(payload.doc.searchFields[i].searchValues) || payload.doc.searchFields[i].searchValues.length === 0) {
-        invalid = true;
-        invalidMsg = "payload.doc.searchFields[" + i + "] must be a key value pair: {searchField: 'key', searchValues: ['value_1']}";
-        break;
-      }
-    }
-  } else if (payload.doc.modifiedDateRange && !(payload.doc.modifiedDateRange.startDateGMT || payload.doc.modifiedDateRange.endDateGMT)) {
-    invalid = true;
-    invalidMsg = "at least one of payload.doc.modifiedDateRange.startDateGMT or payload.doc.modifiedDateRange.endDateGMT must be provided"
-  } else if (payload.doc.modifiedDateRange && payload.doc.modifiedDateRange.startDateGMT && payload.doc.modifiedDateRange.endDateGMT && (payload.doc.modifiedDateRange.startDateGMT > payload.doc.modifiedDateRange.endDateGMT)) {
-    invalid = true;
-    invalidMsg = "startDateGMT must have a date before endDateGMT";
-  }
-
-  //If callback is not a function
-  if (!callback) {
-    throw new Error("A callback function was not provided");
-  } else if (typeof callback !== 'function') {
-    throw new TypeError("callback is not a function")
-  }
-
-  if (!invalid) {
-    let request = require('request');
-
-    let url = `${channelProfile.channelSettingsValues.protocol}://ordermanagementreporting${channelProfile.channelSettingsValues.environment}.iqmetrix.net/v1`
-
-    /*
-     Create query string for searching orders by specific fields
-     */
-    let queryParams = [];
-    let filterParams = [];
-    let uris = [];
-
-    if (payload.doc.remoteIDs) {
-      /*
-       Add remote IDs as a query parameter
-       */
-      payload.doc.remoteIDs.forEach((remoteID) => {
-        let endpoint = "/Reports/OrderList/report?filter=companyId eq " + channelProfile.channelAuthValues.company_id + " and id eq " + remoteID;
-        uris.push(endpoint);
-      });
-
-    } else if (payload.doc.modifiedDateRange) {
-      /*
-       Add modified date ranges to the query
-       iQmetrix only supports exclusive compare operator so skew each by 1 ms to create an equivalent inclusive range
-       */
-      if (payload.doc.modifiedDateRange.startDateGMT) {
-        filterParams.push("updatedUtc gt " + new Date(Date.parse(payload.doc.modifiedDateRange.startDateGMT) - 1).toISOString());
-      }
-      if (payload.doc.modifiedDateRange.endDateGMT) {
-        filterParams.push("updatedUtc lt " + new Date(Date.parse(payload.doc.modifiedDateRange.endDateGMT) + 1).toISOString());
-      }
-
-      let endpoint = "/Reports/OrderList/report?filter=companyId eq " + channelProfile.channelAuthValues.company_id + " and " + filterParams.join(' and ');
-      uris.push(endpoint);
-    }
-
-    /*
-     Add page to the query
-     */
-    if (payload.doc.page) {
-      queryParams.push("&page=" + payload.doc.page);
-    }
-
-    /*
-     Add pageSize to the query
-     */
-    if (payload.doc.pageSize) {
-      queryParams.push("&pageSize=" + payload.doc.pageSize);
-    }
-
-    uris.forEach(function(uri) {
-      // Add the authorization header
-      let headers = {
-        "Authorization": "Bearer " + channelProfile.channelAuthValues.access_token
-      };
-
-      /*
-       Set URL and headers
-       */
-      let options = {
-        url: url + uri + queryParams.join(''),
-        headers: headers,
-        json: true
-      };
-
-      log("Using URL [" + url + uri + queryParams.join('') + "]", ncUtil);
-
-      // Pass in our URL and headers
-      request(options, async function (error, response, body) {
-        try {
-          if (!error) {
-            console.log(body);
-            log("Do GetPaymentCaptureFromQuery Callback", ncUtil);
-            out.response.endpointStatusCode = response.statusCode;
-            out.response.endpointStatusMessage = response.statusMessage;
-
-            if (response.statusCode === 200 && body.rows.length > 0) {
-              if (body.rows.length < body.totalRecords) {
-                out.ncStatusCode = 206;
-              } else {
-                out.ncStatusCode = 200;
-              }
-
-              //For each order, get the order detail (i.e. paymentCapture)
-              let paymentCapturePromises = body.rows.map((order) => {
-                let paymentCapture = {
-                  response: {}
-                };
-
-                let endPoint = "/Companies(" + channelProfile.channelAuthValues.company_id + ")/OrderDetails(" + order._id + ")";
-                let url = `${channelProfile.channelSettingsValues.protocol}://ordermanagementreporting${channelProfile.channelSettingsValues.environment}.iqmetrix.net/v1${endPoint}`;
-                options.url = url;
-
-                log("Using URL [" + url + "]", ncUtil);
-
-                return new Promise((resolve, reject) => {
-                  try {
-                    request(options, function (error, response, body) {
-                      if (!error) {
-                        paymentCapture.response.endpointStatusCode = response.statusCode;
-                        paymentCapture.response.endpointStatusMessage = response.statusMessage;
-
-                        if (response.statusCode === 200) {
-                          paymentCapture.ncStatusCode = 200;
-                          paymentCapture.doc = body;
-                          paymentCapture.paymentCaptureRemoteID = body.id;
-                          paymentCapture.paymentCaptureBusinessReference = nc.extractBusinessReferences(channelProfile.paymentCaptureBusinessReferences, body);
-
-                        } else if (response.statusCode === 429) {
-                          paymentCapture.ncStatusCode = 429;
-                          paymentCapture.error = body;
-                        } else if (response.statusCode === 500) {
-                          paymentCapture.ncStatusCode = 500;
-                          paymentCapture.error = body;
-                        } else {
-                          paymentCapture.ncStatusCode = 400;
-                          paymentCapture.error = body;
-                        }
-                      } else {
-                        logError("Do GetPaymentCaptureFromQuery Callback error - " + error, ncUtil);
-                        paymentCapture.error = error;
-                        paymentCapture.ncStatusCode = 500;
-                      }
-
-                      resolve(paymentCapture);
-                    });
-                  } catch (err) {
-                    let rej = {payload: {}};
-                    rej.ncStatusCode = 500;
-                    rej.payload.error = {err: err, stack: err.stackTrace};
-                    reject(rej);
-                  }
-                });
-              });
-
-              try {
-                out.payload = await Promise.all(paymentCapturePromises);
-              } catch (rejected) {
-                out.ncStatusCode = rejected.ncStatusCode;
-                out.payload = rejected.payload;
-              }
-
-            } else if (response.statusCode === 200) {
-              out.ncStatusCode = 204;
-            } else if (response.statusCode === 429) {
-              out.ncStatusCode = 429;
-              out.payload.error = body;
-            } else if (response.statusCode === 500) {
-              out.ncStatusCode = 500;
-              out.payload.error = body;
-            } else {
-              out.ncStatusCode = 400;
-              out.payload.error = body;
-            }
-
-            callback(out);
-          } else {
-            logError("Do GetPaymentCaptureFromQuery Callback error - " + error, ncUtil);
-            out.payload.error = error;
-            out.ncStatusCode = 500;
-            callback(out);
-          }
-        } catch (err) {
-          logError("Exception occurred in GetPaymentCaptureFromQuery - " + err, ncUtil);
-          out.payload.error = {err: err, stack: err.stackTrace};
-          out.ncStatusCode = 500;
-          callback(out);
-        }
+  initializeStubFunction()
+    .then(searchForOrders)
+    .then(buildResponseObject)
+    .catch(handleError)
+    .then(() => callback(stub.out))
+    .catch(error => {
+      logError(`The callback function threw an exception: ${error}`);
+      setTimeout(() => {
+        throw error;
       });
     });
-  } else {
-    log("Callback with an invalid request - " + invalidMsg, ncUtil);
-    out.ncStatusCode = 400;
-    out.payload.error = invalidMsg;
-    callback(out);
+
+  async function initializeStubFunction() {
+    if (!stub.isValid) {
+      stub.messages.forEach(msg => logError(msg));
+      stub.out.ncStatusCode = 400;
+      throw new Error(`Invalid request [${stub.messages.join(" ")}]`);
+    }
+
+    logInfo("Stub function is valid.");
+
+    companyId = stub.channelProfile.channelAuthValues.company_id;
+    page = stub.payload.doc.page;
+    pageSize = stub.payload.doc.pageSize;
+
+    return JSON.parse(JSON.stringify(stub.payload.doc));
+  }
+
+  async function searchForOrders(queryDoc) {
+    const filters = [`companyId eq ${companyId}`];
+    let orders = [];
+
+    switch (stub.queryType) {
+      case "remoteIDs": {
+        orders = await remoteIdSearch(queryDoc.remoteIDs);
+        break;
+      }
+
+      case "createdDateRange": {
+        filters.push(`createdUtc gt ${new Date(Date.parse(queryDoc.createdDateRange.startDateGMT) - 1).toISOString()}`);
+        filters.push(`createdUtc lt ${new Date(Date.parse(queryDoc.createdDateRange.endDateGMT) + 1).toISOString()}`);
+        orders = await dateRangeSearch(filters);
+        break;
+      }
+
+      case "modifiedDateRange": {
+        filters.push(
+          `updatedUtc gt ${new Date(Date.parse(queryDoc.modifiedDateRange.startDateGMT) - 1).toISOString()}`
+        );
+        filters.push(`updatedUtc lt ${new Date(Date.parse(queryDoc.modifiedDateRange.endDateGMT) + 1).toISOString()}`);
+        orders = await dateRangeSearch(filters);
+        break;
+      }
+
+      default: {
+        stub.out.ncStatusCode = 400;
+        throw new Error(`Invalid request, unknown query type: '${stub.queryType}'`);
+      }
+    }
+    return orders;
+  }
+
+  async function remoteIdSearch(remoteIds) {
+    remoteIds = [...new Set(remoteIds)];
+    totalResults = remoteIds.length;
+    const startIndex = (page - 1) * pageSize;
+    const endIndex = page * pageSize;
+    const orders = [];
+    for (const remoteId of remoteIds.slice(startIndex, endIndex)) {
+      const order = await getOrderDetail(remoteId);
+      order.orderFull = await getOrderFull(order.invoiceNumber);
+      orders.push(order);
+    }
+    return orders;
+  }
+
+  async function dateRangeSearch(filters) {
+    const orderReport = await getOrderReport(filters);
+    totalResults = orderReport.totalRecords;
+    const orders = [];
+    for (const row of orderReport.rows) {
+      const order = await getOrderDetail(row._id);
+      order.orderFull = await getOrderFull(order.invoiceNumber);
+      orders.push(order);
+    }
+    return orders;
+  }
+
+  async function getOrderReport(filters) {
+    const filter = filters.join(" and ");
+    logInfo(`Getting order report with filter: '${filter}'`);
+
+    const req = stub.requestPromise.get(
+      Object.assign({}, stub.requestDefaults, {
+        method: "GET",
+        baseUrl: stub.getBaseUrl("ordermanagementreporting"),
+        url: "/v1/Reports/OrderList/report",
+        qs: {
+          filter: filter,
+          page: page,
+          pageSize: pageSize,
+          sortBy: "createdUtc",
+          sortOrder: "asc"
+        }
+      })
+    );
+    logInfo(`Calling: ${req.method} ${req.uri.href}`);
+
+    const resp = await req;
+    stub.out.response.endpointStatusCode = resp.statusCode;
+    stub.out.response.endpointStatusMessage = resp.statusMessage;
+
+    if (resp.timingPhases) {
+      logInfo(`Order report request completed in ${Math.round(resp.timingPhases.total)} milliseconds.`);
+    }
+
+    if (!resp.body || !nc.isArray(resp.body.rows) || !nc.isNumber(resp.body.totalRecords)) {
+      throw new TypeError(
+        "Order report response is not in expected format, expected rows[] and totalRecords properties."
+      );
+    }
+
+    logInfo(`Order report response contains ${resp.body.rows.length} of ${resp.body.totalRecords} records.`);
+
+    return resp.body;
+  }
+
+  async function getOrderDetail(orderId) {
+    logInfo(`Getting order detail for order '${orderId}'`);
+
+    const req = stub.requestPromise.get(
+      Object.assign({}, stub.requestDefaults, {
+        method: "GET",
+        baseUrl: stub.getBaseUrl("ordermanagementreporting"),
+        url: `/v1/Companies(${companyId})/OrderDetails(${orderId})`
+      })
+    );
+    logInfo(`Calling: ${req.method} ${req.uri.href}`);
+
+    const resp = await req;
+    stub.out.response.endpointStatusCode = resp.statusCode;
+    stub.out.response.endpointStatusMessage = resp.statusMessage;
+
+    if (resp.timingPhases) {
+      logInfo(`Order detail request completed in ${Math.round(resp.timingPhases.total)} milliseconds.`);
+    }
+
+    if (!resp.body || !resp.body.id || !resp.body.invoiceNumber) {
+      throw new TypeError("Order detail response is not in expected format, expected id and invoiceNumber properties.");
+    }
+
+    return resp.body;
+  }
+
+  async function getOrderFull(orderId) {
+    logInfo(`Getting order full details for order '${orderId}'`);
+
+    const req = stub.requestPromise.get(
+      Object.assign({}, stub.requestDefaults, {
+        method: "GET",
+        baseUrl: stub.getBaseUrl("salesorder"),
+        url: `/v1/Companies(${companyId})/PrintableId(${orderId})`
+      })
+    );
+    logInfo(`Calling: ${req.method} ${req.uri.href}`);
+
+    const resp = await req;
+    stub.out.response.endpointStatusCode = resp.statusCode;
+    stub.out.response.endpointStatusMessage = resp.statusMessage;
+
+    if (resp.timingPhases) {
+      logInfo(`Order full details request completed in ${Math.round(resp.timingPhases.total)} milliseconds.`);
+    }
+
+    if (!resp.body || !resp.body.Id || !nc.isArray(resp.body.SalesOrders)) {
+      throw new TypeError(
+        "Order full details response is not in expected format, expected an Id and SalesOrders[] properties."
+      );
+    }
+
+    if (resp.body.SalesOrders.length === 0) {
+      throw new TypeError("Order full details response did not contain any SalesOrders.");
+    }
+
+    if (resp.body.SalesOrders.length > 1) {
+      throw new TypeError("Order full details response contained multiple SalesOrders.");
+    }
+
+    return resp.body.SalesOrders[0];
+  }
+
+  async function buildResponseObject(orders) {
+    if (orders.length > 0) {
+      logInfo(`Submitting ${orders.length} orders for payment capture...`);
+
+      stub.out.payload = [];
+      orders.forEach(order => {
+        stub.out.payload.push({
+          doc: order,
+          paymentCaptureRemoteID: order.id,
+          paymentCaptureBusinessReference: nc.extractBusinessReferences(
+            stub.channelProfile.paymentCaptureBusinessReferences,
+            order
+          )
+        });
+      });
+
+      stub.out.ncStatusCode = page * pageSize <= totalResults ? 206 : 200;
+    } else {
+      logInfo("No orders for payment capture found.");
+      stub.out.ncStatusCode = 204;
+    }
+
+    return stub.out;
+  }
+
+  async function handleError(error) {
+    logError(error);
+    if (error.name === "StatusCodeError") {
+      stub.out.response.endpointStatusCode = error.statusCode;
+      stub.out.response.endpointStatusMessage = error.message;
+
+      if (error.statusCode >= 500) {
+        stub.out.ncStatusCode = 500;
+      } else if ([429, 401].includes(error.statusCode)) {
+        stub.out.ncStatusCode = error.statusCode;
+      } else {
+        stub.out.ncStatusCode = 400;
+      }
+    }
+    stub.out.payload.error = error;
+    stub.out.ncStatusCode = stub.out.ncStatusCode || 500;
+
+    return stub.out;
+  }
+
+  function logInfo(msg) {
+    stub.log(msg, "info");
+  }
+
+  function logWarn(msg) {
+    stub.log(msg, "warn");
+  }
+
+  function logError(msg) {
+    stub.log(msg, "error");
   }
 };
-
-function logError(msg, ncUtil) {
-  console.log("[error] " + msg);
-}
-
-function log(msg, ncUtil) {
-  console.log("[info] " + msg);
-}
-
-module.exports.GetPaymentCaptureFromQuery = GetPaymentCaptureFromQuery;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nchannel/iqmetrix-dropship-channel",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
   "scripts": {
     "test": "mocha --timeout 2000 validation/*.spec.js"
   },
-  "version": "0.0.51"
+  "version": "0.0.52"
 }

--- a/schema/GetPaymentCapture.json
+++ b/schema/GetPaymentCapture.json
@@ -1,5 +1,5 @@
 {
-  "name": "iQmetrix DropShip Get Fulfillment Schema",
+  "name": "iQmetrix DropShip Get PaymentCapture Schema",
   "schemaDef": {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "type": "object",
@@ -214,162 +214,145 @@
       "orderFull": {
         "type": "object",
         "properties": {
-          "Items": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "ItemExtensions": {
-                  "type": "array"
-                },
-                "Id": {
-                  "type": "string"
-                },
-                "OrderId": {
-                  "type": "string"
-                },
-                "ItemTypeId": {
-                  "type": "number"
-                },
-                "ItemType": {
-                  "type": "string"
-                },
-                "ItemStatusId": {
-                  "type": "number"
-                },
-                "ItemStatus": {
-                  "type": "string"
-                },
-                "ProductId": {
-                  "type": "string"
-                },
-                "SupplierEntityId": {
-                  "type": "number"
-                },
-                "Quantity": {
-                  "type": "number"
-                },
-                "Cost": {
-                  "type": "number"
-                },
-                "ListPrice": {
-                  "type": "number"
-                },
-                "SellingPrice": {
-                  "type": "number"
-                },
-                "Index": {
-                  "type": "number"
-                },
-                "Description": {
-                  "type": "string"
-                },
-                "SKU": {
-                  "type": "string"
-                },
-                "Notes": {
-                  "type": "null"
-                },
-                "SerialNumbers": {
-                  "type": "array"
-                },
-                "SupplierReference": {
-                  "type": "null"
-                },
-                "TrackingInformation": {
-                  "type": "array"
-                },
-                "ShippingOptionId": {
-                  "type": "string"
-                },
-                "DeliveryRemarks": {
-                  "type": "null"
-                },
-                "DeliveryDate": {
-                  "type": "null"
-                }
-              }
-            }
-          },
           "Id": {
             "type": "string"
           },
-          "OrderTypeId": {
+          "DateCreatedUtc": {
+            "type": "string"
+          },
+          "DateInsertedUtc": {
+            "type": "string"
+          },
+          "DateUpdatedUtc": {
+            "type": "string"
+          },
+          "CompanyId": {
             "type": "number"
           },
-          "OrderType": {
-            "type": "string"
-          },
-          "State": {
-            "type": "string"
-          },
-          "PrintableId": {
-            "type": "string"
-          },
-          "Name": {
-            "type": "string"
-          },
-          "TenderId": {
-            "type": "string"
-          },
-          "TenderOrigin": {
-            "type": "null"
-          },
-          "SourceId": {
-            "type": "null"
-          },
-          "SourceName": {
-            "type": "null"
-          },
-          "OrderReference": {
-            "type": "string"
-          },
-          "EntityId": {
-            "type": "number"
-          },
-          "ShippingEntityId": {
+          "LocationId": {
             "type": "number"
           },
           "CustomerId": {
             "type": "string"
           },
-          "BillingCustomerId": {
-            "type": "string"
+          "ExpiryDateUtc": {
+            "type": "null"
           },
-          "ShippingCustomerId": {
-            "type": "string"
+          "Items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "LineNumber": {
+                  "type": "number"
+                },
+                "ProductCatalogId": {
+                  "type": "string"
+                },
+                "Quantity": {
+                  "type": "number"
+                },
+                "Price": {
+                  "type": "number"
+                },
+                "PricingTermId": {
+                  "type": "null"
+                },
+                "CorrelationId": {
+                  "type": "string"
+                },
+                "ItemType": {
+                  "type": "string"
+                },
+                "SupplierEntityId": {
+                  "type": "number"
+                },
+                "SerialNumber": {
+                  "type": "null"
+                },
+                "TaxLineItems": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "TaxName": {
+                        "type": "string"
+                      },
+                      "TaxableAmount": {
+                        "type": "number"
+                      },
+                      "Rate": {
+                        "type": "number"
+                      },
+                      "Tax": {
+                        "type": "number"
+                      },
+                      "IqTaxServiceId": {
+                        "type": "null"
+                      }
+                    }
+                  }
+                }
+              }
+            }
           },
-          "ShippingAddressId": {
+          "Payments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "Id": {
+                  "type": "string"
+                },
+                "AuthCode": {
+                  "type": "null"
+                },
+                "TransactionNumber": {
+                  "type": "null"
+                },
+                "Token": {
+                  "type": "null"
+                },
+                "Amount": {
+                  "type": "number"
+                },
+                "PaymentMethodId": {
+                  "type": "string"
+                },
+                "CorrelationId": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          "TaxCalculationResultId": {
             "type": "string"
           },
           "BillingAddressId": {
             "type": "string"
           },
-          "EmployeeId": {
-            "type": "number"
-          },
-          "DiscountCode": {
-            "type": "null"
-          },
-          "DiscountDescription": {
-            "type": "null"
-          },
-          "DiscountAmount": {
-            "type": "number"
-          },
-          "CreatedDateUtc": {
+          "ShippingAddressId": {
             "type": "string"
           },
-          "OrderExpiryHours": {
-            "type": "number"
-          },
-          "OrderExpiryDate": {
+          "PrintableId": {
             "type": "string"
+          },
+          "DropshipOrderId": {
+            "type": "string"
+          },
+          "UserId": {
+            "type": "null"
+          },
+          "ShippingLineItems": {
+            "type": "array"
+          },
+          "DiscountLineItems": {
+            "type": "array"
           }
         }
       }
     }
   },
-  "tags": ["iQmetrix", "Fulfillment", "Get", "OrderDetails", "Dropship"],
+  "tags": ["iQmetrix", "PaymentCapture", "Get", "OrderDetails", "Dropship"],
   "audit": {}
 }

--- a/validation/functions.json
+++ b/validation/functions.json
@@ -44,6 +44,9 @@
   "GetFulfillmentFromQuery": {
     "statusCodes": [200, 204, 206, 400, 429, 500]
   },
+  "GetPaymentCaptureFromQuery": {
+    "statusCodes": [200, 204, 206, 400, 429, 500]
+  },
   "GetProductMatrixFromQuery": {
     "statusCodes": [200, 204, 206, 400, 429, 500]
   },


### PR DESCRIPTION
Add additional API calls to GetFulfillment and GetPaymentCapture.
Refactor GetFulfillment and GetPaymentCapture to match project style.

GetFulfillment and GetPaymentCapture stub functions were written in a very different style than the rest of the project, including a different request module.  I had trouble following the mix of async/await, Promises, and standard node style callbacks and determining where to make the necessary changes for the additional api calls.  I found it much easier to refactor the functions to match the style used throughout the rest of the project.